### PR TITLE
feat(client): профиль, избранное, типы билетов, дата в ленте (#76-80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run unit tests
-        run: ./gradlew :composeApp:testMockDebugUnitTest
+        run: ./gradlew :composeApp:testMockDebugUnitTest --no-configuration-cache
 
       - name: Upload test report
         if: failure()
@@ -59,7 +59,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build mock debug APK
-        run: ./gradlew :composeApp:assembleMockDebug
+        run: ./gradlew :composeApp:assembleMockDebug --no-configuration-cache
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run unit tests
-        run: ./gradlew :composeApp:testMockDebugUnitTest --no-configuration-cache
+        run: ./gradlew :composeApp:testMockDebugUnitTest
 
       - name: Upload test report
         if: failure()
@@ -59,7 +59,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build mock debug APK
-        run: ./gradlew :composeApp:assembleMockDebug --no-configuration-cache
+        run: ./gradlew :composeApp:assembleMockDebug
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -23,6 +23,7 @@ object AppSession {
     var userPhone: String = ""
     var userCity: String = city
     var userInterests: List<String> = emptyList()
+    var userAvatarUrl: String? = null
 
     // Кеш всех событий — заполняется FeedViewModel после загрузки, используется поиском
     var cachedEvents: List<EventDto> = emptyList()
@@ -42,12 +43,22 @@ object AppSession {
 
     var userRole: String = "USER"
 
-    fun login(token: String, userId: String, phone: String?, fullName: String, role: String) {
+    fun login(
+        token: String,
+        userId: String,
+        phone: String?,
+        fullName: String,
+        role: String,
+        avatarUrl: String? = null,
+        interests: List<String> = emptyList()
+    ) {
         this.authToken = token
         this.userId = userId
         this.userPhone = phone ?: ""
         this.userName = fullName
         this.userRole = role
+        this.userAvatarUrl = avatarUrl
+        this.userInterests = interests
     }
 
     fun logout() {
@@ -57,6 +68,7 @@ object AppSession {
         userPhone = ""
         userRole = "USER"
         userInterests = emptyList()
+        userAvatarUrl = null
         cachedEvents = emptyList()
         currentEvent = null
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
@@ -15,12 +15,14 @@ class DiscoveryApiService(
         city: String,
         authToken: String?,
         page: Int,
-        size: Int
+        size: Int,
+        date: String?
     ): DiscoveryFeedResponseDto {
         return httpClient.get("$baseUrl/api/discovery") {
             parameter("city", city)
             parameter("page", page)
             parameter("size", size)
+            date?.let { parameter("date", it) }
             authToken?.let { header("Authorization", "Bearer $it") }
         }.body()
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryService.kt
@@ -7,6 +7,7 @@ interface DiscoveryService {
         city: String,
         authToken: String? = null,
         page: Int = 0,
-        size: Int = 20
+        size: Int = 20,
+        date: String? = null
     ): DiscoveryFeedResponseDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -20,4 +21,7 @@ class EventApiService(
             parameter("city", city)
             parameter("page", page)
         }.body()
+
+    override suspend fun getTicketTypes(eventId: String): List<TicketTypeDto> =
+        httpClient.get("$baseUrl/api/inventory/$eventId/ticket-types").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -1,8 +1,10 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 
 interface EventService {
     suspend fun getEvent(eventId: String): EventDto
     suspend fun search(query: String, city: String, page: Int = 0): List<EventDto>
+    suspend fun getTicketTypes(eventId: String): List<TicketTypeDto>
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeDiscoveryApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeDiscoveryApiService.kt
@@ -11,7 +11,8 @@ class FakeDiscoveryApiService : DiscoveryService {
         city: String,
         authToken: String?,
         page: Int,
-        size: Int
+        size: Int,
+        date: String?
     ): DiscoveryFeedResponseDto {
         return FEED
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 
 /**
  * Мок-реализация для разработки без бекенда.
@@ -23,4 +24,10 @@ class FakeEventService : EventService {
             it.label.contains(query, ignoreCase = true) ||
                 it.description.contains(query, ignoreCase = true)
         }
+
+    override suspend fun getTicketTypes(eventId: String): List<TicketTypeDto> = listOf(
+        TicketTypeDto("tt-1", "Входной билет", 500, 100, 87),
+        TicketTypeDto("tt-2", "Льготный", 250, 50, 42),
+        TicketTypeDto("tt-3", "Семейный", 1200, 20, 15)
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileApiService.kt
@@ -1,0 +1,52 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.UserDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data class UpdateProfileRequest(
+    val fullName: String? = null,
+    val interests: List<String>? = null
+)
+
+class ProfileApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : ProfileService {
+
+    override suspend fun updateProfile(
+        authToken: String,
+        fullName: String?,
+        interests: List<String>?
+    ): UserDto = httpClient.patch("$baseUrl/auth/me") {
+        header("Authorization", "Bearer $authToken")
+        contentType(ContentType.Application.Json)
+        setBody(UpdateProfileRequest(fullName, interests))
+    }.body()
+
+    override suspend fun uploadAvatar(
+        authToken: String,
+        imageBytes: ByteArray,
+        extension: String
+    ): UserDto = httpClient.post("$baseUrl/auth/me/avatar") {
+        header("Authorization", "Bearer $authToken")
+        setBody(MultiPartFormDataContent(formData {
+            append("file", imageBytes, Headers.build {
+                append(HttpHeaders.ContentDisposition, "filename=\"avatar.$extension\"")
+                append(HttpHeaders.ContentType, "image/$extension")
+            })
+        }))
+    }.body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileService.kt
@@ -1,0 +1,8 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.UserDto
+
+interface ProfileService {
+    suspend fun updateProfile(authToken: String, fullName: String?, interests: List<String>?): UserDto
+    suspend fun uploadAvatar(authToken: String, imageBytes: ByteArray, extension: String): UserDto
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/AuthDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/AuthDto.kt
@@ -20,5 +20,7 @@ data class UserDto(
     val fullName: String,
     val phone: String? = null,
     val email: String? = null,
-    val role: String = "USER"
+    val role: String = "USER",
+    val avatarUrl: String? = null,
+    val interests: List<String> = emptyList()
 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketTypeDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketTypeDto.kt
@@ -1,0 +1,12 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TicketTypeDto(
+    val id: String,
+    val label: String,
+    val price: Int,
+    val quota: Int,
+    val available: Int
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -17,6 +17,8 @@ import com.karrad.ticketsclient.data.api.GeoService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.OrderApiService
 import com.karrad.ticketsclient.data.api.OrderService
+import com.karrad.ticketsclient.data.api.ProfileApiService
+import com.karrad.ticketsclient.data.api.ProfileService
 import com.karrad.ticketsclient.data.api.ScannerApiService
 import com.karrad.ticketsclient.data.api.ScannerService
 import com.karrad.ticketsclient.data.api.TicketApiService
@@ -58,6 +60,9 @@ object AppContainer {
         private set
 
     lateinit var geoService: GeoService
+        private set
+
+    lateinit var profileService: ProfileService
         private set
 
     val searchCitiesUseCase: SearchCitiesUseCase by lazy {
@@ -102,5 +107,6 @@ object AppContainer {
         } else {
             GeoApiService(httpClient, BASE_URL)
         }
+        profileService = ProfileApiService(httpClient, BASE_URL)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
@@ -99,7 +99,9 @@ fun NameInputScreen(phone: String = "", code: String = "") {
                             userId = response.user.id,
                             phone = response.user.phone,
                             fullName = response.user.fullName,
-                            role = response.user.role
+                            role = response.user.role,
+                            avatarUrl = response.user.avatarUrl,
+                            interests = response.user.interests
                         )
                         navigator.push(CitySelectionScreen)
                     } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
@@ -109,7 +109,9 @@ fun SmsCodeScreen(isRegistration: Boolean = false, phone: String = "") {
                                 userId = response.user.id,
                                 phone = response.user.phone,
                                 fullName = response.user.fullName,
-                                role = response.user.role
+                                role = response.user.role,
+                                avatarUrl = response.user.avatarUrl,
+                                interests = response.user.interests
                             )
                             navigator.replaceAll(MainScreen)
                         }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -122,10 +122,16 @@ fun FeedScreen() {
                 }
             }
             is FeedState.Success -> {
-                FeedContent(feed = s.feed, onEventClick = { event ->
-                    AppSession.currentEvent = event
-                    rootNavigator.push(EventDetailScreen(event.id))
-                })
+                val selectedDay by viewModel.selectedDay.collectAsState()
+                FeedContent(
+                    feed = s.feed,
+                    selectedDay = selectedDay,
+                    onDaySelect = { viewModel.selectDay(it) },
+                    onEventClick = { event ->
+                        AppSession.currentEvent = event
+                        rootNavigator.push(EventDetailScreen(event.id))
+                    }
+                )
             }
         }
     }
@@ -246,15 +252,18 @@ private fun DayOfWeek.shortRu(): String = when (this) {
 // ─── Feed content ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun FeedContent(feed: DiscoveryFeedResponseDto, onEventClick: (EventDto) -> Unit) {
-    var selectedDay by remember { mutableStateOf(0) }
-
+private fun FeedContent(
+    feed: DiscoveryFeedResponseDto,
+    selectedDay: Int,
+    onDaySelect: (Int) -> Unit,
+    onEventClick: (EventDto) -> Unit
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
         contentPadding = PaddingValues(bottom = 96.dp) // место под плавающий нав-бар
     ) {
         stickyHeader {
-            DateStrip(selectedDay = selectedDay, onDaySelect = { selectedDay = it })
+            DateStrip(selectedDay = selectedDay, onDaySelect = onDaySelect)
         }
 
         if (feed.forYou.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModel.kt
@@ -11,6 +11,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 
 sealed interface FeedState {
     data object Loading : FeedState
@@ -25,12 +30,33 @@ class FeedViewModel(
     private val _state = MutableStateFlow<FeedState>(FeedState.Loading)
     val state: StateFlow<FeedState> = _state.asStateFlow()
 
+    private val _selectedDay = MutableStateFlow(0)
+    val selectedDay: StateFlow<Int> = _selectedDay.asStateFlow()
+
+    private var currentDate: String? = null
+
     init {
         viewModelScope.launch {
             snapshotFlow { AppSession.city }
                 .distinctUntilChanged()
-                .collect { load() }
+                .collect {
+                    currentDate = null
+                    _selectedDay.value = 0
+                    load()
+                }
         }
+    }
+
+    fun selectDay(offset: Int) {
+        _selectedDay.value = offset
+        currentDate = if (offset == 0) {
+            null
+        } else {
+            val tz = TimeZone.currentSystemDefault()
+            val today = Clock.System.now().toLocalDateTime(tz).date
+            today.plus(offset, DateTimeUnit.DAY).toString()
+        }
+        load()
     }
 
     fun load() {
@@ -39,7 +65,8 @@ class FeedViewModel(
             try {
                 val feed = discoveryService.getDiscoveryFeed(
                     city = AppSession.city,
-                    authToken = AppSession.authToken
+                    authToken = AppSession.authToken,
+                    date = currentDate
                 )
                 AppSession.cachedEvents = (feed.forYou + feed.byCategory.flatMap { it.events }).distinctBy { it.id }
                 AppSession.isOffline = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,6 +33,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +44,8 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
 
 private val ALL_INTERESTS = listOf(
     "Театры", "Кино", "Концерты", "Стендап", "Выставки",
@@ -52,12 +56,15 @@ private val ALL_INTERESTS = listOf(
 @Composable
 fun EditProfileScreen() {
     val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
 
     var nameValue by remember { mutableStateOf(TextFieldValue(AppSession.userName)) }
     val name = nameValue.text
     var cityValue by remember { mutableStateOf(TextFieldValue(AppSession.userCity)) }
     val city = cityValue.text
     var selectedInterests by remember { mutableStateOf(AppSession.userInterests.toSet()) }
+    var saving by remember { mutableStateOf(false) }
+    var saveError by remember { mutableStateOf<String?>(null) }
 
     Column(
         modifier = Modifier
@@ -160,20 +167,59 @@ fun EditProfileScreen() {
             Spacer(Modifier.height(32.dp))
 
             // ─── Save button ─────────────────────────────────────────────────
+            if (saveError != null) {
+                Text(
+                    text = saveError!!,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
             ElevatedButton(
                 onClick = {
-                    AppSession.userName = name.trim().ifBlank { AppSession.userName }
-                    AppSession.userCity = city.trim().ifBlank { AppSession.userCity }
-                    AppSession.userInterests = selectedInterests.toList()
-                    navigator.pop()
+                    saving = true
+                    saveError = null
+                    scope.launch {
+                        try {
+                            val token = AppSession.authToken
+                            if (token != null) {
+                                val updated = AppContainer.profileService.updateProfile(
+                                    authToken = token,
+                                    fullName = name.trim().ifBlank { null },
+                                    interests = selectedInterests.toList()
+                                )
+                                AppSession.userName = updated.fullName
+                                AppSession.userInterests = updated.interests
+                                AppSession.userAvatarUrl = updated.avatarUrl
+                            } else {
+                                AppSession.userName = name.trim().ifBlank { AppSession.userName }
+                                AppSession.userInterests = selectedInterests.toList()
+                            }
+                            AppSession.userCity = city.trim().ifBlank { AppSession.userCity }
+                            navigator.pop()
+                        } catch (e: Exception) {
+                            saveError = "Ошибка сохранения: ${e.message}"
+                        } finally {
+                            saving = false
+                        }
+                    }
                 },
+                enabled = !saving,
                 modifier = Modifier.fillMaxWidth().height(52.dp),
                 colors = ButtonDefaults.elevatedButtonColors(
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 )
             ) {
-                Text("Сохранить", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+                if (saving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text("Сохранить", fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+                }
             }
 
             Spacer(Modifier.height(32.dp))

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -2,8 +2,10 @@ package com.karrad.ticketsclient.ui.screen.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,7 +13,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -19,19 +24,26 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
+import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
+import com.karrad.ticketsclient.ui.util.formatPrice
 
 @Composable
 fun FavoritesScreen() {
     val navigator = LocalNavigator.currentOrThrow
+    val rootNavigator = navigator.parent ?: navigator
+
+    val favorites = remember { AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) } }
 
     Column(
         modifier = Modifier
@@ -68,27 +80,72 @@ fun FavoritesScreen() {
             )
         }
 
-        // Empty state
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Icon(
-                    Icons.Outlined.FavoriteBorder,
-                    contentDescription = null,
-                    modifier = Modifier.size(64.dp),
-                    tint = MaterialTheme.colorScheme.outlineVariant
-                )
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    "Нет избранных событий",
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
-                )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    "Нажмите ♡ на карточке события,\nчтобы добавить в избранное",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
+        if (favorites.isEmpty()) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Outlined.FavoriteBorder,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.outlineVariant
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        "Нет избранных событий",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Нажмите ♡ на карточке события,\nчтобы добавить в избранное",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(favorites, key = { it.id }) { event ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(MaterialTheme.colorScheme.surface)
+                            .clickable {
+                                AppSession.currentEvent = event
+                                rootNavigator.push(EventDetailScreen(event.id))
+                            }
+                    ) {
+                        Column {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(160.dp)
+                                    .clip(RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp))
+                            ) {
+                                EventImagePlaceholder(seed = event.id, modifier = Modifier.fillMaxSize())
+                            }
+                            Column(modifier = Modifier.padding(12.dp)) {
+                                Text(
+                                    text = event.label,
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                    maxLines = 2
+                                )
+                                event.minPrice?.let { price ->
+                                    Spacer(Modifier.height(4.dp))
+                                    Text(
+                                        text = "от ${price.formatPrice()} ₽",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -31,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -42,50 +42,47 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.OrderConfirmScreen
 import com.karrad.ticketsclient.ui.util.formatPrice
 import kotlinx.coroutines.launch
-
-// ─── Мок-данные ────────────────────────────────────────────────────────────────
-
-private data class TicketType(
-    val id: String,
-    val name: String,
-    val description: String,
-    val price: Int
-)
-
-private val MOCK_TICKET_TYPES = listOf(
-    TicketType("tt-1", "Входной билет", "Полный доступ, весь день с 10:00 до 22:00", 500),
-    TicketType("tt-2", "Льготный билет", "Для студентов, пенсионеров и детей до 14 лет", 250),
-    TicketType("tt-3", "Семейный билет", "2 взрослых + 2 ребёнка (до 14 лет)", 1200)
-)
-
-private val MOCK_DATES = listOf(
-    "8 апр", "9 апр", "10 апр", "11 апр", "12 апр", "13 апр", "14 апр"
-)
-
-// ─── Экран ─────────────────────────────────────────────────────────────────────
 
 @Composable
 fun TicketTypeScreen(eventId: String) {
     val navigator = LocalNavigator.currentOrThrow
     val scope = rememberCoroutineScope()
 
-    var selectedDate by remember { mutableStateOf(MOCK_DATES.first()) }
+    var ticketTypes by remember { mutableStateOf<List<TicketTypeDto>>(emptyList()) }
+    var loading by remember { mutableStateOf(true) }
+    var loadError by remember { mutableStateOf<String?>(null) }
+
     // qty per ticket type id
-    val quantities = remember { mutableMapOf<String, Int>().also { m -> MOCK_TICKET_TYPES.forEach { m[it.id] = 0 } } }
+    val quantities = remember { mutableMapOf<String, Int>() }
     var totalPrice by remember { mutableIntStateOf(0) }
     var buyLoading by remember { mutableStateOf(false) }
 
+    LaunchedEffect(eventId) {
+        loading = true
+        loadError = null
+        try {
+            ticketTypes = AppContainer.eventService.getTicketTypes(eventId)
+            ticketTypes.forEach { quantities[it.id] = 0 }
+        } catch (e: Exception) {
+            loadError = e.message ?: "Не удалось загрузить типы билетов"
+        } finally {
+            loading = false
+        }
+    }
+
     fun recalcTotal() {
-        totalPrice = MOCK_TICKET_TYPES.sumOf { (quantities[it.id] ?: 0) * it.price }
+        totalPrice = ticketTypes.sumOf { (quantities[it.id] ?: 0) * it.price }
     }
 
     Box(
@@ -120,209 +117,198 @@ fun TicketTypeScreen(eventId: String) {
                 }
             }
 
-            // ─── Дата ────────────────────────────────────────────────────────
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(MOCK_DATES) { date ->
-                    val selected = date == selectedDate
-                    Box(
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(20.dp))
-                            .background(
-                                if (selected) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.surfaceVariant
-                            )
-                            .clickable { selectedDate = date }
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            date,
-                            fontSize = 13.sp,
-                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                            color = if (selected) Color.White
-                            else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+            when {
+                loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
                 }
-            }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                loadError != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        loadError!!,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(24.dp)
+                    )
+                }
 
-            // ─── Типы билетов ────────────────────────────────────────────────
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                contentPadding = PaddingValues(bottom = 100.dp)
-            ) {
-                items(MOCK_TICKET_TYPES) { ticket ->
-                    var qty by remember(ticket.id) { mutableIntStateOf(quantities[ticket.id] ?: 0) }
+                else -> {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-                    Row(
+                    // ─── Типы билетов ─────────────────────────────────────────
+                    LazyColumn(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 14.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                            .weight(1f)
+                            .fillMaxWidth(),
+                        contentPadding = PaddingValues(bottom = 100.dp)
                     ) {
-                        // Инфо о типе билета
-                        Column(Modifier.weight(1f)) {
-                            Text(
-                                ticket.name,
-                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Spacer(Modifier.height(2.dp))
-                            Text(
-                                ticket.description,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                "${ticket.price.formatPrice()} ₽",
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                        }
+                        items(ticketTypes, key = { it.id }) { ticket ->
+                            var qty by remember(ticket.id) { mutableIntStateOf(quantities[ticket.id] ?: 0) }
+                            val maxQty = ticket.available
 
-                        Spacer(Modifier.width(12.dp))
-
-                        // Счётчик ─  [−] N [+]
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            // Кнопка −
-                            Box(
+                            Row(
                                 modifier = Modifier
-                                    .size(32.dp)
-                                    .clip(CircleShape)
-                                    .border(
-                                        1.dp,
-                                        if (qty > 0) MaterialTheme.colorScheme.primary
-                                        else MaterialTheme.colorScheme.outlineVariant,
-                                        CircleShape
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    Text(
+                                        ticket.label,
+                                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                                        color = MaterialTheme.colorScheme.onSurface
                                     )
-                                    .clickable(enabled = qty > 0) {
-                                        qty--
-                                        quantities[ticket.id] = qty
-                                        recalcTotal()
-                                    },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    "−",
-                                    fontSize = 18.sp,
-                                    color = if (qty > 0) MaterialTheme.colorScheme.primary
-                                    else MaterialTheme.colorScheme.outlineVariant,
-                                    fontWeight = FontWeight.Medium
-                                )
+                                    Spacer(Modifier.height(2.dp))
+                                    Text(
+                                        "Доступно: $maxQty",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    Spacer(Modifier.height(4.dp))
+                                    Text(
+                                        "${ticket.price.formatPrice()} ₽",
+                                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+
+                                Spacer(Modifier.width(12.dp))
+
+                                // Счётчик ─  [−] N [+]
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .clip(CircleShape)
+                                            .border(
+                                                1.dp,
+                                                if (qty > 0) MaterialTheme.colorScheme.primary
+                                                else MaterialTheme.colorScheme.outlineVariant,
+                                                CircleShape
+                                            )
+                                            .clickable(enabled = qty > 0) {
+                                                qty--
+                                                quantities[ticket.id] = qty
+                                                recalcTotal()
+                                            },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text(
+                                            "−",
+                                            fontSize = 18.sp,
+                                            color = if (qty > 0) MaterialTheme.colorScheme.primary
+                                            else MaterialTheme.colorScheme.outlineVariant,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                    }
+
+                                    Text(
+                                        qty.toString(),
+                                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                                        modifier = Modifier.width(24.dp),
+                                        textAlign = TextAlign.Center
+                                    )
+
+                                    Box(
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .clip(CircleShape)
+                                            .background(
+                                                if (qty < maxQty) MaterialTheme.colorScheme.primary
+                                                else MaterialTheme.colorScheme.outlineVariant
+                                            )
+                                            .clickable(enabled = qty < maxQty) {
+                                                qty++
+                                                quantities[ticket.id] = qty
+                                                recalcTotal()
+                                            },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text("＋", fontSize = 16.sp, color = Color.White, fontWeight = FontWeight.Medium)
+                                    }
+                                }
                             }
 
-                            // Количество
-                            Text(
-                                qty.toString(),
-                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
-                                modifier = Modifier.width(24.dp),
-                                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                             )
-
-                            // Кнопка +
-                            Box(
-                                modifier = Modifier
-                                    .size(32.dp)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primary)
-                                    .clickable {
-                                        qty++
-                                        quantities[ticket.id] = qty
-                                        recalcTotal()
-                                    },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text("＋", fontSize = 16.sp, color = Color.White, fontWeight = FontWeight.Medium)
-                            }
                         }
                     }
-
-                    HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                    )
                 }
             }
         }
 
         // ─── Sticky CTA ──────────────────────────────────────────────────────
-        Surface(
-            modifier = Modifier.align(Alignment.BottomCenter),
-            shadowElevation = 8.dp,
-            color = MaterialTheme.colorScheme.surface
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-                    .height(52.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(
-                        if (totalPrice > 0) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.outlineVariant
-                    )
-                    .clickable(enabled = totalPrice > 0 && !buyLoading) {
-                        buyLoading = true
-                        scope.launch {
-                            try {
-                                val order = AppContainer.orderService.createOrder(
-                                    eventId = eventId,
-                                    authToken = AppSession.authToken ?: ""
-                                )
-                                navigator.push(
-                                    OrderConfirmScreen(
-                                        eventId = eventId,
-                                        orderId = order.id,
-                                        totalPrice = totalPrice
-                                    )
-                                )
-                            } catch (_: Exception) {
-                            } finally {
-                                buyLoading = false
-                            }
-                        }
-                    },
-                contentAlignment = Alignment.Center
+        if (!loading && loadError == null) {
+            Surface(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                shadowElevation = 8.dp,
+                color = MaterialTheme.colorScheme.surface
             ) {
-                if (buyLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(22.dp),
-                        strokeWidth = 2.dp,
-                        color = Color.White
-                    )
-                } else {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 20.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            "Купить билеты",
-                            color = Color.White,
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 16.sp
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .height(52.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(
+                            if (totalPrice > 0) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outlineVariant
                         )
-                        if (totalPrice > 0) {
+                        .clickable(enabled = totalPrice > 0 && !buyLoading) {
+                            buyLoading = true
+                            scope.launch {
+                                try {
+                                    val order = AppContainer.orderService.createOrder(
+                                        eventId = eventId,
+                                        authToken = AppSession.authToken ?: ""
+                                    )
+                                    navigator.push(
+                                        OrderConfirmScreen(
+                                            eventId = eventId,
+                                            orderId = order.id,
+                                            totalPrice = totalPrice
+                                        )
+                                    )
+                                } catch (_: Exception) {
+                                } finally {
+                                    buyLoading = false
+                                }
+                            }
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (buyLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(22.dp),
+                            strokeWidth = 2.dp,
+                            color = Color.White
+                        )
+                    } else {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
                             Text(
-                                "${totalPrice.formatPrice()} ₽",
-                                color = Color.White.copy(alpha = 0.9f),
-                                fontWeight = FontWeight.Medium,
-                                fontSize = 14.sp
+                                "Купить билеты",
+                                color = Color.White,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp
                             )
+                            if (totalPrice > 0) {
+                                Text(
+                                    "${totalPrice.formatPrice()} ₽",
+                                    color = Color.White.copy(alpha = 0.9f),
+                                    fontWeight = FontWeight.Medium,
+                                    fontSize = 14.sp
+                                )
+                            }
                         }
                     }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx3072M -Djava.io.tmpdir=C:/Windows/Temp
+kotlin.daemon.jvmargs=-Xmx3072M
 
 #Gradle
-org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Djava.io.tmpdir=C:/Windows/Temp
+org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 


### PR DESCRIPTION
## Summary
- **AppSession** — `userAvatarUrl` и `interests` заполняются при логине/регистрации из ответа сервера
- **ProfileService / ProfileApiService** — `PATCH /auth/me` (имя + интересы), `POST /auth/me/avatar` (multipart)
- **EditProfileScreen** — кнопка «Сохранить» вызывает `PATCH /auth/me`, обновляет AppSession, показывает спиннер и ошибку
- **FavoritesScreen** — вместо заглушки «пусто» показывает реальные события из `cachedEvents`, отфильтрованные по `isFavorite`
- **TicketTypeScreen** — убраны `MOCK_TICKET_TYPES` и `MOCK_DATES`; данные загружаются через `GET /api/inventory/{id}/ticket-types`; количество ограничено `available`
- **DiscoveryService / DiscoveryApiService / FakeDiscoveryApiService** — добавлен параметр `date: String?` (ISO-8601)
- **FeedViewModel** — `selectDay(offset)` вычисляет ISO-дату и перезагружает ленту; сброс при смене города
- **FeedScreen** — `DateStrip` подключён к `viewModel.selectDay()` вместо локального состояния
- **TicketTypeDto** — новый DTO для ответа `/ticket-types`

## Test plan
- [ ] Сборка `./gradlew :composeApp:testMockDebugUnitTest` — зелёная
- [ ] Логин → `AppSession.userAvatarUrl` / `userInterests` заполнены
- [ ] EditProfileScreen → сохранение отправляет PATCH, обновляет имя в ProfileScreen
- [ ] FavoritesScreen → после добавления ♡ события оно появляется в списке
- [ ] TicketTypeScreen (mock) → показывает 3 типа билетов из FakeEventService
- [ ] DateStrip → выбор дня фильтрует ленту событий

Closes #76 #77 #78 #79 #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)