### PR TITLE
fix(client): #84-85-86-88 SeatMap API, OrderConfirm, тесты, удаление currentEvent

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -15,9 +15,6 @@ object AppSession {
 
     var city: String by mutableStateOf("Москва")
 
-    /** Set before pushing EventDetailScreen; read inside that screen. */
-    var currentEvent: EventDto? = null
-
     // Profile — заполняется при входе/регистрации
     var userName: String = ""
     var userPhone: String = ""
@@ -70,6 +67,5 @@ object AppSession {
         userInterests = emptyList()
         userAvatarUrl = null
         cachedEvents = emptyList()
-        currentEvent = null
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -24,4 +25,7 @@ class EventApiService(
 
     override suspend fun getTicketTypes(eventId: String): List<TicketTypeDto> =
         httpClient.get("$baseUrl/api/inventory/$eventId/ticket-types").body()
+
+    override suspend fun getSeatMap(eventId: String): SeatMapDto =
+        httpClient.get("$baseUrl/api/inventory/$eventId/seat-map").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -1,10 +1,12 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 
 interface EventService {
     suspend fun getEvent(eventId: String): EventDto
     suspend fun search(query: String, city: String, page: Int = 0): List<EventDto>
     suspend fun getTicketTypes(eventId: String): List<TicketTypeDto>
+    suspend fun getSeatMap(eventId: String): SeatMapDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -1,6 +1,10 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SeatItemDto
+import com.karrad.ticketsclient.data.api.dto.SeatMapDto
+import com.karrad.ticketsclient.data.api.dto.SeatRowDto
+import com.karrad.ticketsclient.data.api.dto.SeatSectionDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 
 /**
@@ -30,4 +34,23 @@ class FakeEventService : EventService {
         TicketTypeDto("tt-2", "Льготный", 250, 50, 42),
         TicketTypeDto("tt-3", "Семейный", 1200, 20, 15)
     )
+
+    override suspend fun getSeatMap(eventId: String): SeatMapDto {
+        val rows = (0..7).map { row ->
+            SeatRowDto(
+                key = "row-$row",
+                label = ('A' + row).toString(),
+                seats = (0..9).map { col ->
+                    val available = !((row == 2 && col in 3..5) ||
+                            (row == 5 && col in 6..8) ||
+                            (row == 1 && col == 8) ||
+                            (row == 4 && col == 2) ||
+                            (row == 6 && col in 0..1) ||
+                            (row == 7 && col in 7..9))
+                    SeatItemDto(key = "${('A' + row)}${col + 1}", price = 1400, available = available)
+                }
+            )
+        }
+        return SeatMapDto(sections = listOf(SeatSectionDto(key = "main", label = "Партер", rows = rows)))
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/SeatMapDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/SeatMapDto.kt
@@ -1,0 +1,29 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SeatMapDto(
+    val sections: List<SeatSectionDto>
+)
+
+@Serializable
+data class SeatSectionDto(
+    val key: String,
+    val label: String,
+    val rows: List<SeatRowDto>
+)
+
+@Serializable
+data class SeatRowDto(
+    val key: String,
+    val label: String,
+    val seats: List<SeatItemDto>
+)
+
+@Serializable
+data class SeatItemDto(
+    val key: String,
+    val price: Int,
+    val available: Boolean
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.LaunchedEffect
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.SeatMapScreen
 import com.karrad.ticketsclient.ui.navigation.TicketTypeScreen
@@ -65,7 +66,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun EventDetailScreen(eventId: String) {
     val navigator = LocalNavigator.currentOrThrow
-    var loadedEvent by remember { mutableStateOf(AppSession.currentEvent?.takeIf { it.id == eventId }) }
+    var loadedEvent by remember { mutableStateOf<EventDto?>(null) }
     var isFavorite by remember { mutableStateOf(AppSession.isFavorite(eventId)) }
     val favoriteColor by animateColorAsState(
         targetValue = if (isFavorite) Color(0xFFE53935) else Color.Black,
@@ -74,9 +75,7 @@ fun EventDetailScreen(eventId: String) {
     )
 
     LaunchedEffect(eventId) {
-        if (loadedEvent == null) {
-            loadedEvent = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
-        }
+        loadedEvent = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
     }
 
     val event = loadedEvent ?: run {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -128,7 +128,6 @@ fun FeedScreen() {
                     selectedDay = selectedDay,
                     onDaySelect = { viewModel.selectDay(it) },
                     onEventClick = { event ->
-                        AppSession.currentEvent = event
                         rootNavigator.push(EventDetailScreen(event.id))
                     }
                 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,20 +35,35 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 import com.karrad.ticketsclient.ui.util.formatPrice
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 @Composable
 fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
     val navigator = LocalNavigator.currentOrThrow
     val scope = rememberCoroutineScope()
-    val event = AppSession.currentEvent
+    var event by remember { mutableStateOf<EventDto?>(null) }
+    var orderStatus by remember { mutableStateOf("PENDING_PAYMENT") }
 
     var loading by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
     var success by remember { mutableStateOf(false) }
+
+    LaunchedEffect(eventId) {
+        event = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
+    }
+
+    LaunchedEffect(orderId) {
+        try {
+            orderStatus = AppContainer.orderService.getOrder(orderId, AppSession.authToken ?: "").status
+        } catch (_: Exception) { }
+    }
 
     Column(
         modifier = Modifier
@@ -109,9 +125,31 @@ fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
             )
             Spacer(Modifier.height(16.dp))
 
-            OrderRow(label = "Событие", value = event?.label ?: eventId)
+            OrderRow(label = "Событие", value = event?.label ?: "…")
+            event?.time?.let { iso ->
+                val dt = try {
+                    Instant.parse(iso).toLocalDateTime(TimeZone.currentSystemDefault())
+                } catch (_: Exception) { null }
+                if (dt != null) {
+                    val dateStr = "%02d.%02d.%04d %02d:%02d".format(
+                        dt.dayOfMonth, dt.monthNumber, dt.year, dt.hour, dt.minute
+                    )
+                    OrderRow(label = "Дата", value = dateStr)
+                }
+            }
             HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
             OrderRow(label = "Номер заказа", value = orderId.takeLast(8).uppercase())
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+            OrderRow(
+                label = "Статус",
+                value = when (orderStatus) {
+                    "PENDING_PAYMENT" -> "Ожидает оплаты"
+                    "PAID" -> "Оплачен"
+                    "EXPIRED" -> "Истёк"
+                    "PAYMENT_FAILED" -> "Ошибка оплаты"
+                    else -> orderStatus
+                }
+            )
             HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
             OrderRow(
                 label = "К оплате",

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -115,7 +115,6 @@ fun FavoritesScreen() {
                             .clip(RoundedCornerShape(14.dp))
                             .background(MaterialTheme.colorScheme.surface)
                             .clickable {
-                                AppSession.currentEvent = event
                                 rootNavigator.push(EventDetailScreen(event.id))
                             }
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -159,7 +159,6 @@ fun SearchScreen() {
             ) {
                 items(results, key = { it.id }) { event ->
                     SearchResultRow(event = event, onClick = {
-                        AppSession.currentEvent = event
                         navigator.push(EventDetailScreen(event.id))
                     })
                 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
@@ -58,7 +58,10 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.runtime.rememberCoroutineScope
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import androidx.compose.runtime.LaunchedEffect
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.OrderConfirmScreen
 import com.karrad.ticketsclient.ui.util.formatPrice
@@ -66,28 +69,24 @@ import kotlinx.coroutines.launch
 
 // ─── Модели ────────────────────────────────────────────────────────────────────
 
-private data class Seat(val row: Int, val col: Int, val available: Boolean)
+private data class Seat(val row: Int, val col: Int, val available: Boolean, val price: Int = 0)
 
 private val SESSION_TIMES = listOf("13:00", "17:00", "23:00")
 
-private fun buildSeats(): List<Seat> {
-    val seats = mutableListOf<Seat>()
-    for (row in 0..7) {
-        for (col in 0..9) {
-            val available = !((row == 2 && col in 3..5) ||
-                    (row == 5 && col in 6..8) ||
-                    (row == 1 && col == 8) ||
-                    (row == 4 && col == 2) ||
-                    (row == 6 && col in 0..1) ||
-                    (row == 7 && col in 7..9))
-            seats += Seat(row, col, available)
-        }
-    }
-    return seats
-}
-
 private fun rowLabel(row: Int) = ('A' + row).toString()
 private fun seatLabel(row: Int, col: Int) = "${rowLabel(row)}${col + 1}"
+
+private fun SeatMapDto.toSeats(): List<Seat> {
+    val result = mutableListOf<Seat>()
+    sections.forEach { section ->
+        section.rows.forEachIndexed { rowIdx, row ->
+            row.seats.forEachIndexed { colIdx, seat ->
+                result += Seat(rowIdx, colIdx, seat.available, seat.price)
+            }
+        }
+    }
+    return result
+}
 
 // ─── Screen ────────────────────────────────────────────────────────────────────
 
@@ -95,9 +94,15 @@ private fun seatLabel(row: Int, col: Int) = "${rowLabel(row)}${col + 1}"
 fun SeatMapScreen(eventId: String) {
     val navigator = LocalNavigator.currentOrThrow
     val scope = rememberCoroutineScope()
-    val event = AppSession.currentEvent
+    var event by remember { mutableStateOf<EventDto?>(null) }
+    var seatMap by remember { mutableStateOf<SeatMapDto?>(null) }
 
-    val allSeats = remember { buildSeats() }
+    LaunchedEffect(eventId) {
+        event = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
+        seatMap = try { AppContainer.eventService.getSeatMap(eventId) } catch (_: Exception) { null }
+    }
+
+    val allSeats = remember(seatMap) { seatMap?.toSeats() ?: emptyList() }
     var selectedTime by remember { mutableStateOf(SESSION_TIMES[1]) }
     var selectedSeats by remember { mutableStateOf(setOf<Seat>()) }
     var buyLoading by remember { mutableStateOf(false) }
@@ -109,8 +114,7 @@ fun SeatMapScreen(eventId: String) {
         offset += panChange
     }
 
-    val seatPrice = 1400
-    val totalPrice = selectedSeats.size * seatPrice
+    val totalPrice = selectedSeats.sumOf { it.price }
 
     Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         Column(
@@ -264,7 +268,7 @@ fun SeatMapScreen(eventId: String) {
                                             in 2..4 -> "а"
                                             else -> "ов"
                                         }
-                                    } · ${seatPrice.formatPrice()} ₽/шт",
+                                    } · ${(selectedSeats.firstOrNull()?.price ?: 0).formatPrice()} ₽/шт",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
@@ -162,7 +162,6 @@ fun TicketsScreen() {
                             time = ticket.eventTime ?: "",
                             minPrice = ticket.price
                         )
-                    AppSession.currentEvent = event
                     rootNavigator.push(EventDetailScreen(event.id))
                 }
             )

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
@@ -1,0 +1,76 @@
+package com.karrad.ticketsclient
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AppSessionTest {
+
+    @BeforeTest
+    fun setUp() {
+        AppSession.logout()
+    }
+
+    @Test
+    fun `login stores token userId and profile fields`() {
+        AppSession.login(
+            token = "tok-123",
+            userId = "u-1",
+            phone = "+79001234567",
+            fullName = "Иван Иванов",
+            role = "USER",
+            avatarUrl = "https://example.com/avatar.jpg",
+            interests = listOf("music", "theatre")
+        )
+
+        assertEquals("tok-123", AppSession.authToken)
+        assertEquals("u-1", AppSession.userId)
+        assertEquals("+79001234567", AppSession.userPhone)
+        assertEquals("Иван Иванов", AppSession.userName)
+        assertEquals("USER", AppSession.userRole)
+        assertEquals("https://example.com/avatar.jpg", AppSession.userAvatarUrl)
+        assertEquals(listOf("music", "theatre"), AppSession.userInterests)
+    }
+
+    @Test
+    fun `logout clears auth token and profile`() {
+        AppSession.login(
+            token = "tok-abc",
+            userId = "u-2",
+            phone = "+79009876543",
+            fullName = "Мария Петрова",
+            role = "ADMIN"
+        )
+
+        AppSession.logout()
+
+        assertNull(AppSession.authToken)
+        assertNull(AppSession.userId)
+        assertEquals("", AppSession.userName)
+        assertEquals("", AppSession.userPhone)
+        assertEquals("USER", AppSession.userRole)
+        assertNull(AppSession.userAvatarUrl)
+        assertEquals(emptyList(), AppSession.userInterests)
+    }
+
+    @Test
+    fun `logout clears cached events`() {
+        AppSession.login(token = "t", userId = "u", phone = null, fullName = "x", role = "USER")
+
+        AppSession.logout()
+
+        assertEquals(emptyList(), AppSession.cachedEvents)
+    }
+
+    @Test
+    fun `login with null phone stores empty string`() {
+        AppSession.login(token = "t", userId = "u", phone = null, fullName = "Test", role = "USER")
+        assertEquals("", AppSession.userPhone)
+    }
+
+    @Test
+    fun `city has default value Moskva`() {
+        assertEquals("Москва", AppSession.city)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/data/api/FakeProfileServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/data/api/FakeProfileServiceTest.kt
@@ -1,0 +1,96 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.AppSession
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class FakeProfileServiceTest {
+
+    private val service = FakeProfileService()
+
+    @BeforeTest
+    fun setUp() {
+        AppSession.logout()
+        AppSession.login(
+            token = "fake-token",
+            userId = "user-42",
+            phone = "+79001112233",
+            fullName = "Алексей Смирнов",
+            role = "USER",
+            interests = listOf("jazz")
+        )
+    }
+
+    @Test
+    fun `updateProfile returns updated fullName`() = runTest {
+        val result = service.updateProfile(
+            authToken = "fake-token",
+            fullName = "Новое Имя",
+            interests = null
+        )
+        assertEquals("Новое Имя", result.fullName)
+    }
+
+    @Test
+    fun `updateProfile keeps existing fullName when null`() = runTest {
+        val result = service.updateProfile(
+            authToken = "fake-token",
+            fullName = null,
+            interests = null
+        )
+        assertEquals("Алексей Смирнов", result.fullName)
+    }
+
+    @Test
+    fun `updateProfile returns updated interests`() = runTest {
+        val result = service.updateProfile(
+            authToken = "fake-token",
+            fullName = null,
+            interests = listOf("classical", "rock")
+        )
+        assertEquals(listOf("classical", "rock"), result.interests)
+    }
+
+    @Test
+    fun `updateProfile keeps existing interests when null`() = runTest {
+        val result = service.updateProfile(
+            authToken = "fake-token",
+            fullName = null,
+            interests = null
+        )
+        assertEquals(listOf("jazz"), result.interests)
+    }
+
+    @Test
+    fun `updateProfile returns correct userId`() = runTest {
+        val result = service.updateProfile("token", null, null)
+        assertEquals("user-42", result.id)
+    }
+
+    @Test
+    fun `uploadAvatar returns avatarUrl with correct extension`() = runTest {
+        val result = service.uploadAvatar(
+            authToken = "fake-token",
+            imageBytes = byteArrayOf(1, 2, 3),
+            extension = "png"
+        )
+        assertTrue(result.avatarUrl?.endsWith(".png") == true)
+        assertNotNull(result.avatarUrl)
+    }
+
+    @Test
+    fun `uploadAvatar returns jpg extension`() = runTest {
+        val result = service.uploadAvatar("token", byteArrayOf(), "jpg")
+        assertTrue(result.avatarUrl?.contains("avatar.jpg") == true)
+    }
+
+    @Test
+    fun `uploadAvatar returns correct userId`() = runTest {
+        val result = service.uploadAvatar("token", byteArrayOf(), "jpg")
+        assertEquals("user-42", result.id)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.karrad.ticketsclient.ui.screen.feed
+
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.DiscoveryService
+import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeedViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val emptyFeed = DiscoveryFeedResponseDto(
+        forYou = emptyList(),
+        byCategory = emptyList(),
+        tomorrow = emptyList(),
+        dayAfterTomorrow = emptyList()
+    )
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        AppSession.logout()
+        AppSession.isOffline = false
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `selectDay updates selectedDay state`() = runTest(testDispatcher) {
+        val vm = FeedViewModel(FakeDiscoveryService(emptyFeed))
+        advanceUntilIdle()
+
+        vm.selectDay(2)
+        advanceUntilIdle()
+
+        assertEquals(2, vm.selectedDay.value)
+    }
+
+    @Test
+    fun `selectDay 0 resets to today`() = runTest(testDispatcher) {
+        val vm = FeedViewModel(FakeDiscoveryService(emptyFeed))
+        advanceUntilIdle()
+
+        vm.selectDay(3)
+        vm.selectDay(0)
+        advanceUntilIdle()
+
+        assertEquals(0, vm.selectedDay.value)
+    }
+
+    @Test
+    fun `successful load results in Success state`() = runTest(testDispatcher) {
+        val vm = FeedViewModel(FakeDiscoveryService(emptyFeed))
+        advanceUntilIdle()
+
+        assertIs<FeedState.Success>(vm.state.value)
+    }
+
+    @Test
+    fun `load failure sets Error state and marks offline`() = runTest(testDispatcher) {
+        val vm = FeedViewModel(ThrowingDiscoveryService())
+        advanceUntilIdle()
+
+        assertIs<FeedState.Error>(vm.state.value)
+        assertTrue(AppSession.isOffline)
+    }
+
+    @Test
+    fun `successful load clears offline flag`() = runTest(testDispatcher) {
+        AppSession.isOffline = true
+        val vm = FeedViewModel(FakeDiscoveryService(emptyFeed))
+        advanceUntilIdle()
+
+        assertEquals(false, AppSession.isOffline)
+    }
+
+    @Test
+    fun `offline fallback shows cached events on Error`() = runTest(testDispatcher) {
+        val vm = FeedViewModel(ThrowingDiscoveryService())
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertIs<FeedState.Error>(state)
+        assertTrue(state.message.isNotBlank())
+    }
+}
+
+private class FakeDiscoveryService(
+    private val feed: DiscoveryFeedResponseDto
+) : DiscoveryService {
+    override suspend fun getDiscoveryFeed(
+        city: String,
+        authToken: String?,
+        page: Int,
+        size: Int,
+        date: String?
+    ): DiscoveryFeedResponseDto = feed
+}
+
+private class ThrowingDiscoveryService : DiscoveryService {
+    override suspend fun getDiscoveryFeed(
+        city: String,
+        authToken: String?,
+        page: Int,
+        size: Int,
+        date: String?
+    ): DiscoveryFeedResponseDto = throw RuntimeException("Network error")
+}


### PR DESCRIPTION
## Summary
- **#84** — `SeatMapDto` + `getSeatMap()` в `EventService`/`EventApiService`/`FakeEventService`; `SeatMapScreen` загружает схему зала из API вместо hardcoded `buildSeats()`
- **#85** — `OrderConfirmScreen` загружает событие по `eventId` через `LaunchedEffect`, показывает дату события и локализованный статус заказа
- **#86** — новые unit-тесты: `AppSessionTest` (5), `FakeProfileServiceTest` (8), `FeedViewModelTest` (6)
- **#88** — удалён `AppSession.currentEvent`; все экраны передают только `eventId` через навигацию

## Test plan
- [ ] `./gradlew :composeApp:testMockDebugUnitTest` — 34 теста, все зелёные
- [ ] SeatMapScreen отображает схему из API (mock-данные соответствуют старому `buildSeats()`)
- [ ] OrderConfirmScreen показывает название события, дату и статус
- [ ] EventDetailScreen, SearchScreen, FavoritesScreen, TicketsScreen — навигация работает без `currentEvent`

Closes #84, #85, #86, #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)