### PR TITLE
fix(client): #100 #98 #101 — AppSession.city, BASE_URL buildConfig, support/about screens

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -95,10 +95,12 @@ android {
             applicationIdSuffix = ".mock"
             versionNameSuffix = "-mock"
             buildConfigField("boolean", "USE_MOCK", "true")
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080\"")
         }
         create("prod") {
             dimension = "mode"
             buildConfigField("boolean", "USE_MOCK", "false")
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080\"")
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
@@ -12,7 +12,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        AppContainer.init(useMock = BuildConfig.USE_MOCK)
+        AppContainer.init(useMock = BuildConfig.USE_MOCK, baseUrl = BuildConfig.BASE_URL)
 
         setContent {
             App()

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -18,7 +18,6 @@ object AppSession {
     // Profile — заполняется при входе/регистрации
     var userName: String = ""
     var userPhone: String = ""
-    var userCity: String = city
     var userInterests: List<String> = emptyList()
     var userAvatarUrl: String? = null
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -35,8 +35,6 @@ import com.karrad.ticketsclient.data.api.createHttpClient
  */
 object AppContainer {
 
-    private const val BASE_URL = "http://10.0.2.2:8080"
-
     var isMock: Boolean = false
         private set
 
@@ -64,48 +62,48 @@ object AppContainer {
     lateinit var profileService: ProfileService
         private set
 
-    fun init(useMock: Boolean) {
+    fun init(useMock: Boolean, baseUrl: String = "http://10.0.2.2:8080") {
         isMock = useMock
         val httpClient = createHttpClient()
         authService = if (useMock) {
             FakeAuthService()
         } else {
-            AuthApiService(httpClient, BASE_URL)
+            AuthApiService(httpClient, baseUrl)
         }
         discoveryService = if (useMock) {
             FakeDiscoveryApiService()
         } else {
-            DiscoveryApiService(httpClient, BASE_URL)
+            DiscoveryApiService(httpClient, baseUrl)
         }
         scannerService = if (useMock) {
             FakeScannerService()
         } else {
-            ScannerApiService(httpClient, BASE_URL)
+            ScannerApiService(httpClient, baseUrl)
         }
         ticketService = if (useMock) {
             FakeTicketService()
         } else {
-            TicketApiService(httpClient, BASE_URL)
+            TicketApiService(httpClient, baseUrl)
         }
         orderService = if (useMock) {
             FakeOrderService()
         } else {
-            OrderApiService(httpClient, BASE_URL)
+            OrderApiService(httpClient, baseUrl)
         }
         eventService = if (useMock) {
             FakeEventService()
         } else {
-            EventApiService(httpClient, BASE_URL)
+            EventApiService(httpClient, baseUrl)
         }
         geoService = if (useMock) {
             FakeGeoService()
         } else {
-            GeoApiService(httpClient, BASE_URL)
+            GeoApiService(httpClient, baseUrl)
         }
         profileService = if (useMock) {
             FakeProfileService()
         } else {
-            ProfileApiService(httpClient, BASE_URL)
+            ProfileApiService(httpClient, baseUrl)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -60,7 +60,7 @@ fun EditProfileScreen() {
 
     var nameValue by remember { mutableStateOf(TextFieldValue(AppSession.userName)) }
     val name = nameValue.text
-    var cityValue by remember { mutableStateOf(TextFieldValue(AppSession.userCity)) }
+    var cityValue by remember { mutableStateOf(TextFieldValue(AppSession.city)) }
     val city = cityValue.text
     var selectedInterests by remember { mutableStateOf(AppSession.userInterests.toSet()) }
     var saving by remember { mutableStateOf(false) }
@@ -195,7 +195,7 @@ fun EditProfileScreen() {
                                 AppSession.userName = name.trim().ifBlank { AppSession.userName }
                                 AppSession.userInterests = selectedInterests.toList()
                             }
-                            AppSession.userCity = city.trim().ifBlank { AppSession.userCity }
+                            AppSession.city = city.trim().ifBlank { AppSession.city }
                             navigator.pop()
                         } catch (e: Exception) {
                             saveError = "Ошибка сохранения: ${e.message}"


### PR DESCRIPTION
## Summary
- **#100** Удалён дублирующий `AppSession.userCity`: `EditProfileScreen` теперь использует `AppSession.city` напрямую
- **#98** `BASE_URL` вынесен в `buildConfigField` для флейворов `mock`/`prod`; `AppContainer.init()` принимает `baseUrl: String`; `MainActivity` передаёт `BuildConfig.BASE_URL`
- **#101** `SupportScreen` и `AboutScreen` уже были реализованы — закрыто как done

## Test plan
- [ ] Тесты `testMockDebugUnitTest` — BUILD SUCCESSFUL (34 tasks)
- [ ] Проверить, что `EditProfileScreen` корректно читает и сохраняет город через `AppSession.city`
- [ ] Проверить, что при сборке `prod`-флейвора `BuildConfig.BASE_URL` доступен

🤖 Generated with [Claude Code](https://claude.com/claude-code)