### PR TITLE
feat(client): #95 #96 #97 — event images, token persistence, favorites API

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
@@ -6,12 +6,15 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.karrad.ticketsclient.data.store.TokenStore
 import com.karrad.ticketsclient.di.AppContainer
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        TokenStore.init(this)
+        AppSession.restoreFromStore()
         AppContainer.init(useMock = BuildConfig.USE_MOCK, baseUrl = BuildConfig.BASE_URL)
 
         setContent {

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.android.kt
@@ -1,0 +1,43 @@
+package com.karrad.ticketsclient.data.store
+
+import android.content.Context
+import android.content.SharedPreferences
+
+actual object TokenStore {
+    private var prefs: SharedPreferences? = null
+
+    /** Вызывать из MainActivity.onCreate перед AppContainer.init */
+    fun init(context: Context) {
+        prefs = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+    }
+
+    actual fun save(snapshot: SessionSnapshot) {
+        prefs?.edit()
+            ?.putString("token", snapshot.token)
+            ?.putString("userId", snapshot.userId)
+            ?.putString("fullName", snapshot.fullName)
+            ?.putString("phone", snapshot.phone)
+            ?.putString("role", snapshot.role)
+            ?.apply()
+    }
+
+    actual fun load(): SessionSnapshot? {
+        val p = prefs ?: return null
+        val token = p.getString("token", null) ?: return null
+        val userId = p.getString("userId", null) ?: return null
+        return SessionSnapshot(
+            token = token,
+            userId = userId,
+            fullName = p.getString("fullName", "") ?: "",
+            phone = p.getString("phone", "") ?: "",
+            role = p.getString("role", "USER") ?: "USER"
+        )
+    }
+
+    actual fun clear() {
+        prefs?.edit()
+            ?.remove("token")?.remove("userId")
+            ?.remove("fullName")?.remove("phone")?.remove("role")
+            ?.apply()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.android.kt
@@ -1,0 +1,8 @@
+package com.karrad.ticketsclient.ui.util
+
+import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+
+actual fun ByteArray.toImageBitmap(): ImageBitmap? =
+    BitmapFactory.decodeByteArray(this, 0, size)?.asImageBitmap()

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -4,10 +4,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.store.SessionSnapshot
+import com.karrad.ticketsclient.data.store.TokenStore
 
 /**
  * In-memory app session. Holds auth state and short-lived navigation data.
- * Не переживает рестарт приложения — токен хранится только в памяти.
+ * Токен сохраняется через TokenStore (SharedPreferences/NSUserDefaults).
  */
 object AppSession {
     var authToken: String? = null
@@ -30,11 +32,15 @@ object AppSession {
     // true если последний запрос к API завершился ошибкой сети
     var isOffline: Boolean by mutableStateOf(false)
 
-    // Локальное избранное (in-memory до реализации бэка, issue #22)
+    // Избранное (in-memory, синхронизируется с API в FavoritesScreen/FeedScreen)
     private val _favorites = mutableSetOf<String>()
     fun isFavorite(eventId: String): Boolean = eventId in _favorites
     fun toggleFavorite(eventId: String, add: Boolean) {
         if (add) _favorites.add(eventId) else _favorites.remove(eventId)
+    }
+    fun setFavorites(ids: Collection<String>) {
+        _favorites.clear()
+        _favorites.addAll(ids)
     }
 
     var userRole: String = "USER"
@@ -55,6 +61,18 @@ object AppSession {
         this.userRole = role
         this.userAvatarUrl = avatarUrl
         this.userInterests = interests
+        TokenStore.save(SessionSnapshot(token, userId, fullName, phone ?: "", role))
+    }
+
+    /** Восстановить сессию из персистентного хранилища (вызывать при старте приложения). */
+    fun restoreFromStore(): Boolean {
+        val s = TokenStore.load() ?: return false
+        authToken = s.token
+        userId = s.userId
+        userName = s.fullName
+        userPhone = s.phone
+        userRole = s.role
+        return true
     }
 
     fun logout() {
@@ -66,5 +84,7 @@ object AppSession {
         userInterests = emptyList()
         userAvatarUrl = null
         cachedEvents = emptyList()
+        _favorites.clear()
+        TokenStore.clear()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeFavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeFavoriteService.kt
@@ -1,0 +1,17 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.EventDto
+
+class FakeFavoriteService : FavoriteService {
+    private val added = mutableSetOf<String>()
+
+    override suspend fun add(eventId: String, token: String) {
+        added.add(eventId)
+    }
+
+    override suspend fun remove(eventId: String, token: String) {
+        added.remove(eventId)
+    }
+
+    override suspend fun list(token: String): List<EventDto> = emptyList()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
@@ -1,0 +1,41 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data class AddFavoriteRequest(val eventId: String)
+
+class FavoriteApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : FavoriteService {
+
+    override suspend fun add(eventId: String, token: String) {
+        httpClient.post("$baseUrl/api/favorites") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(AddFavoriteRequest(eventId))
+        }
+    }
+
+    override suspend fun remove(eventId: String, token: String) {
+        httpClient.delete("$baseUrl/api/favorites/$eventId") {
+            bearerAuth(token)
+        }
+    }
+
+    override suspend fun list(token: String): List<EventDto> =
+        httpClient.get("$baseUrl/api/favorites") {
+            bearerAuth(token)
+        }.body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteService.kt
@@ -1,0 +1,9 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.EventDto
+
+interface FavoriteService {
+    suspend fun add(eventId: String, token: String)
+    suspend fun remove(eventId: String, token: String)
+    suspend fun list(token: String): List<EventDto>
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.kt
@@ -1,0 +1,19 @@
+package com.karrad.ticketsclient.data.store
+
+data class SessionSnapshot(
+    val token: String,
+    val userId: String,
+    val fullName: String,
+    val phone: String,
+    val role: String
+)
+
+/**
+ * Персистентное хранилище токена аутентификации.
+ * Android: SharedPreferences; iOS: NSUserDefaults.
+ */
+expect object TokenStore {
+    fun save(snapshot: SessionSnapshot)
+    fun load(): SessionSnapshot?
+    fun clear()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -17,7 +17,10 @@ import com.karrad.ticketsclient.data.api.GeoService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.OrderApiService
 import com.karrad.ticketsclient.data.api.OrderService
+import com.karrad.ticketsclient.data.api.FakeFavoriteService
 import com.karrad.ticketsclient.data.api.FakeProfileService
+import com.karrad.ticketsclient.data.api.FavoriteApiService
+import com.karrad.ticketsclient.data.api.FavoriteService
 import com.karrad.ticketsclient.data.api.ProfileApiService
 import com.karrad.ticketsclient.data.api.ProfileService
 import com.karrad.ticketsclient.data.api.ScannerApiService
@@ -62,9 +65,16 @@ object AppContainer {
     lateinit var profileService: ProfileService
         private set
 
+    lateinit var favoriteService: FavoriteService
+        private set
+
+    lateinit var httpClient: io.ktor.client.HttpClient
+        private set
+
     fun init(useMock: Boolean, baseUrl: String = "http://10.0.2.2:8080") {
         isMock = useMock
         val httpClient = createHttpClient()
+        this.httpClient = httpClient
         authService = if (useMock) {
             FakeAuthService()
         } else {
@@ -104,6 +114,11 @@ object AppContainer {
             FakeProfileService()
         } else {
             ProfileApiService(httpClient, baseUrl)
+        }
+        favoriteService = if (useMock) {
+            FakeFavoriteService()
+        } else {
+            FavoriteApiService(httpClient, baseUrl)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/component/EventImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/component/EventImage.kt
@@ -1,0 +1,45 @@
+package com.karrad.ticketsclient.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import com.karrad.ticketsclient.data.cache.CachedImageLoader
+import com.karrad.ticketsclient.data.cache.ImageCache
+import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
+import com.karrad.ticketsclient.ui.util.toImageBitmap
+
+/**
+ * Показывает изображение события по URL с кешированием.
+ * При отсутствии URL или ошибке загрузки показывает [EventImagePlaceholder].
+ */
+@Composable
+fun EventImage(imageUrl: String?, seed: String, modifier: Modifier = Modifier) {
+    var bitmap by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
+
+    LaunchedEffect(imageUrl) {
+        if (!imageUrl.isNullOrBlank()) {
+            val bytes = CachedImageLoader.load(AppContainer.httpClient, imageUrl, ImageCache.EVENT_IMAGE_TTL_MS)
+            bitmap = bytes?.toImageBitmap()
+        }
+    }
+
+    val b = bitmap
+    if (b != null) {
+        Image(
+            bitmap = b,
+            contentDescription = null,
+            modifier = modifier,
+            contentScale = ContentScale.Crop
+        )
+    } else {
+        EventImagePlaceholder(seed = seed, modifier = modifier)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -57,6 +57,7 @@ import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.SeatMapScreen
 import com.karrad.ticketsclient.ui.navigation.TicketTypeScreen
+import com.karrad.ticketsclient.ui.component.EventImage
 import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
 import com.karrad.ticketsclient.ui.util.formatPrice
 import kotlinx.datetime.Instant
@@ -101,7 +102,7 @@ fun EventDetailScreen(eventId: String) {
                     .fillMaxWidth()
                     .height(280.dp)
             ) {
-                EventImagePlaceholder(seed = event.id, modifier = Modifier.fillMaxSize())
+                EventImage(imageUrl = event.imageUrl, seed = event.id, modifier = Modifier.fillMaxSize())
 
                 // тёмный градиент снизу
                 Box(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -41,8 +41,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,6 +62,7 @@ import com.karrad.ticketsclient.data.api.dto.CategoryEventsEntryDto
 import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.component.EventImage
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 import com.karrad.ticketsclient.ui.navigation.SearchScreen
 import com.karrad.ticketsclient.ui.screen.tickets.OfflineBanner
@@ -359,6 +362,7 @@ private fun EventCard(
 ) {
     val widthMod = if (cardWidth != null) Modifier.width(cardWidth) else Modifier.fillMaxWidth()
     var isFav by remember { mutableStateOf(AppSession.isFavorite(event.id)) }
+    val scope = rememberCoroutineScope()
 
     Column(modifier = widthMod.clickable { onClick() }) {
         // ── Фото ──────────────────────────────────────────────────────────────
@@ -368,7 +372,7 @@ private fun EventCard(
                 .height(imageHeight)
                 .clip(RoundedCornerShape(14.dp))
         ) {
-            EventImagePlaceholder(seed = event.id, modifier = Modifier.fillMaxSize())
+            EventImage(imageUrl = event.imageUrl, seed = event.id, modifier = Modifier.fillMaxSize())
 
             // Age rating — top left (полупрозрачный тёмный)
             Box(
@@ -395,8 +399,22 @@ private fun EventCard(
                     .clip(CircleShape)
                     .background(Color.Black.copy(alpha = 0.35f))
                     .clickable {
-                        isFav = !isFav
-                        AppSession.toggleFavorite(event.id, isFav)
+                        val newFav = !isFav
+                        isFav = newFav
+                        AppSession.toggleFavorite(event.id, newFav)
+                        val token = AppSession.authToken
+                        if (token != null) {
+                            scope.launch {
+                                runCatching {
+                                    if (newFav) AppContainer.favoriteService.add(event.id, token)
+                                    else AppContainer.favoriteService.remove(event.id, token)
+                                }.onFailure {
+                                    // rollback on error
+                                    isFav = !newFav
+                                    AppSession.toggleFavorite(event.id, !newFav)
+                                }
+                            }
+                        }
                     }
             ) {
                 Icon(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -24,7 +24,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,16 +39,34 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
+import com.karrad.ticketsclient.ui.component.EventImage
 import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
 import com.karrad.ticketsclient.ui.util.formatPrice
-
 @Composable
 fun FavoritesScreen() {
     val navigator = LocalNavigator.currentOrThrow
     val rootNavigator = navigator.parent ?: navigator
+    val scope = rememberCoroutineScope()
 
-    val favorites = remember { AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) } }
+    var favorites by remember { mutableStateOf<List<EventDto>>(emptyList()) }
+    var loading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        val token = AppSession.authToken
+        if (token != null) {
+            runCatching { AppContainer.favoriteService.list(token) }
+                .onSuccess { list ->
+                    favorites = list
+                    AppSession.setFavorites(list.map { it.id })
+                }
+        } else {
+            favorites = AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) }
+        }
+        loading = false
+    }
 
     Column(
         modifier = Modifier
@@ -125,7 +148,7 @@ fun FavoritesScreen() {
                                     .height(160.dp)
                                     .clip(RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp))
                             ) {
-                                EventImagePlaceholder(seed = event.id, modifier = Modifier.fillMaxSize())
+                                EventImage(imageUrl = event.imageUrl, seed = event.id, modifier = Modifier.fillMaxSize())
                             }
                             Column(modifier = Modifier.padding(12.dp)) {
                                 Text(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.kt
@@ -1,0 +1,6 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+/** Декодирует байты изображения в [ImageBitmap]. Возвращает null при ошибке. */
+expect fun ByteArray.toImageBitmap(): ImageBitmap?

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.ios.kt
@@ -1,0 +1,32 @@
+package com.karrad.ticketsclient.data.store
+
+import platform.Foundation.NSUserDefaults
+
+actual object TokenStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    actual fun save(snapshot: SessionSnapshot) {
+        defaults.setObject(snapshot.token, "token")
+        defaults.setObject(snapshot.userId, "userId")
+        defaults.setObject(snapshot.fullName, "fullName")
+        defaults.setObject(snapshot.phone, "phone")
+        defaults.setObject(snapshot.role, "role")
+    }
+
+    actual fun load(): SessionSnapshot? {
+        val token = defaults.stringForKey("token") ?: return null
+        val userId = defaults.stringForKey("userId") ?: return null
+        return SessionSnapshot(
+            token = token,
+            userId = userId,
+            fullName = defaults.stringForKey("fullName") ?: "",
+            phone = defaults.stringForKey("phone") ?: "",
+            role = defaults.stringForKey("role") ?: "USER"
+        )
+    }
+
+    actual fun clear() {
+        listOf("token", "userId", "fullName", "phone", "role")
+            .forEach { defaults.removeObjectForKey(it) }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/ImageDecoder.ios.kt
@@ -1,0 +1,8 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+import org.jetbrains.skia.Image
+
+actual fun ByteArray.toImageBitmap(): ImageBitmap? = runCatching {
+    Image.makeFromEncoded(this).toComposeImageBitmap()
+}.getOrNull()


### PR DESCRIPTION
## Summary
- **#95** `EventImage` composable загружает изображение по `imageUrl` через `CachedImageLoader` (TTL 1 час); `expect/actual toImageBitmap()` для Android (BitmapFactory) и iOS (Skia); FeedScreen, EventDetailScreen, FavoritesScreen обновлены
- **#96** `TokenStore` (expect/actual) — Android: `SharedPreferences`, iOS: `NSUserDefaults`; `AppSession.login()` сохраняет, `logout()` очищает, `restoreFromStore()` восстанавливает сессию при старте
- **#97** `FavoriteService` / `FavoriteApiService` / `FakeFavoriteService`; `AppContainer.favoriteService`; `FavoritesScreen` загружает список из `GET /api/favorites`; toggle в `FeedScreen` вызывает API async с rollback при ошибке

## Test plan
- [ ] `testMockDebugUnitTest` — BUILD SUCCESSFUL
- [ ] Перезапустить приложение — токен должен сохраняться
- [ ] Добавить/убрать из избранного — изменения синхронизируются с API
- [ ] Открыть ленту с событиями с `imageUrl` — загружаются реальные изображения

🤖 Generated with [Claude Code](https://claude.com/claude-code)