### PR TITLE
fix: утечка сессии, iOS restoreFromStore, дублирующиеся импорты

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -84,6 +84,7 @@ object AppSession {
         userInterests = emptyList()
         userAvatarUrl = null
         cachedEvents = emptyList()
+        cachedTickets = emptyList()
         _favorites.clear()
         TokenStore.clear()
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
@@ -37,10 +37,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import cafe.adriel.voyager.navigator.tab.CurrentTab
 import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.Tab

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/SupportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/SupportScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material3.Icon

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/MainViewController.kt
@@ -5,5 +5,6 @@ import com.karrad.ticketsclient.di.AppContainer
 
 fun MainViewController() = ComposeUIViewController {
     AppContainer.init(useMock = false)
+    AppSession.restoreFromStore()
     App()
 }


### PR DESCRIPTION
## Summary
- **AppSession.logout()** — добавлен `cachedTickets = emptyList()`; без этого билеты предыдущего пользователя оставались в памяти после выхода
- **MainViewController (iOS)** — добавлен `AppSession.restoreFromStore()`; iOS теперь восстанавливает токен и профиль при перезапуске приложения (паритет с Android)
- **Дублирующиеся импорты** — удалены из FavoritesScreen, AboutScreen, SupportScreen, SearchScreen (`outlined.ArrowBack` — артефакт предыдущего фикса sed) и из MainScreen (runtime imports повторялись дважды)

## Test plan
- [ ] Android/iOS: войти в аккаунт → выйти → проверить что TicketsScreen пустой
- [ ] iOS: войти → перезапустить приложение → пользователь остаётся авторизованным
- [ ] Компиляция без warnings о неиспользуемых импортах

🤖 Generated with [Claude Code](https://claude.com/claude-code)