### PR TITLE
fix: EncryptedSharedPreferences, allowBackup=false, prod BASE_URL

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
             implementation(libs.camerax.lifecycle)
             implementation(libs.camerax.view)
             implementation(libs.mlkit.barcode)
+            implementation(libs.androidx.security.crypto)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
@@ -100,7 +101,10 @@ android {
         create("prod") {
             dimension = "mode"
             buildConfigField("boolean", "USE_MOCK", "false")
-            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080\"")
+            buildConfigField(
+                "String", "BASE_URL",
+                "\"${project.findProperty("PROD_BASE_URL") ?: "https://api.example.com"}\""
+            )
         }
     }
 

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/data/store/TokenStore.android.kt
@@ -2,13 +2,24 @@ package com.karrad.ticketsclient.data.store
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 
 actual object TokenStore {
     private var prefs: SharedPreferences? = null
 
     /** Вызывать из MainActivity.onCreate перед AppContainer.init */
     fun init(context: Context) {
-        prefs = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            "secure_auth_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     actual fun save(snapshot: SessionSnapshot) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,7 @@ org.gradle.caching=true
 #Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+
+# Production server URL — override in CI or local.properties
+# Example: PROD_BASE_URL=https://api.yourdomain.com
+PROD_BASE_URL=https://api.example.com

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.13.2"
+androidx-security-crypto = "1.1.0-alpha06"
 camerax = "1.4.2"
 mlkit-barcode = "17.3.0"
 kotlinx-datetime = "0.6.2"
@@ -54,6 +55,7 @@ camerax-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "ca
 camerax-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
 camerax-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 mlkit-barcode = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkit-barcode" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 [plugins]


### PR DESCRIPTION
Closes #108
Closes #109
Closes #110

## Summary
- `TokenStore.android.kt`: `SharedPreferences` → `EncryptedSharedPreferences` (AES256-GCM); добавлена зависимость `androidx.security:security-crypto`
- `AndroidManifest.xml`: `android:allowBackup=\"false\"` — токен не попадает в Google Backup
- `build.gradle.kts` (prod flavor): `BASE_URL` читается из `PROD_BASE_URL` gradle property (заменяет захардкоженный `10.0.2.2:8080`); значение по умолчанию — `https://api.example.com`, заменить перед prod-билдом

## Test plan
- [x] Компиляция без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)