### PR TITLE
fix: #115 #116 #117 — несовпадения DTO с бэком, logout API

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/AuthApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/AuthApiService.kt
@@ -6,6 +6,7 @@ import com.karrad.ticketsclient.data.api.dto.RegisterRequest
 import com.karrad.ticketsclient.data.api.dto.SendCodeRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -34,4 +35,10 @@ class AuthApiService(
             contentType(ContentType.Application.Json)
             setBody(RegisterRequest(phone, code, fullName))
         }.body()
+
+    override suspend fun logout(token: String) {
+        httpClient.post("$baseUrl/auth/logout") {
+            bearerAuth(token)
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/AuthService.kt
@@ -6,4 +6,5 @@ interface AuthService {
     suspend fun sendCode(phone: String)
     suspend fun login(phone: String, code: String): AuthResponseDto
     suspend fun register(phone: String, code: String, fullName: String): AuthResponseDto
+    suspend fun logout(token: String)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
@@ -18,7 +18,7 @@ class DiscoveryApiService(
         size: Int,
         date: String?
     ): DiscoveryFeedResponseDto {
-        return httpClient.get("$baseUrl/api/discovery") {
+        return httpClient.get("$baseUrl/api/v1/discovery") {
             parameter("city", city)
             parameter("page", page)
             parameter("size", size)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -14,7 +14,7 @@ class EventApiService(
 ) : EventService {
 
     override suspend fun getEvent(eventId: String): EventDto =
-        httpClient.get("$baseUrl/api/events/$eventId").body()
+        httpClient.get("$baseUrl/api/v1/events/$eventId").body()
 
     override suspend fun search(
         query: String,
@@ -23,7 +23,7 @@ class EventApiService(
         dateFrom: String?,
         dateTo: String?
     ): List<EventDto> =
-        httpClient.get("$baseUrl/api/events/search") {
+        httpClient.get("$baseUrl/api/v1/events/search") {
             parameter("q", query)
             parameter("city", city)
             parameter("page", page)
@@ -32,8 +32,8 @@ class EventApiService(
         }.body()
 
     override suspend fun getTicketTypes(eventId: String): List<TicketTypeDto> =
-        httpClient.get("$baseUrl/api/inventory/$eventId/ticket-types").body()
+        httpClient.get("$baseUrl/api/v1/inventory/$eventId/ticket-types").body()
 
     override suspend fun getSeatMap(eventId: String): SeatMapDto =
-        httpClient.get("$baseUrl/api/inventory/$eventId/seat-map").body()
+        httpClient.get("$baseUrl/api/v1/inventory/$eventId/seat-map").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeAuthService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeAuthService.kt
@@ -39,4 +39,8 @@ class FakeAuthService : AuthService {
             )
         )
     }
+
+    override suspend fun logout(token: String) {
+        // Мок: выход всегда успешен
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeGeoService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeGeoService.kt
@@ -2,6 +2,7 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CategoryDto
 import com.karrad.ticketsclient.data.api.dto.CityDto
+import com.karrad.ticketsclient.data.api.dto.SubjectDto
 
 /**
  * Мок-реализация для разработки без бекенда.
@@ -9,29 +10,29 @@ import com.karrad.ticketsclient.data.api.dto.CityDto
 class FakeGeoService : GeoService {
 
     override suspend fun getCities(): List<CityDto> = listOf(
-        CityDto("c-msk",   "Москва",           "Москва"),
-        CityDto("c-spb",   "Санкт-Петербург",  "Санкт-Петербург"),
-        CityDto("c-kzn",   "Казань",           "Республика Татарстан"),
-        CityDto("c-ufa",   "Уфа",              "Республика Башкортостан"),
-        CityDto("c-ekt",   "Екатеринбург",     "Свердловская область"),
-        CityDto("c-nvs",   "Новосибирск",      "Новосибирская область"),
-        CityDto("c-krd",   "Краснодар",        "Краснодарский край"),
-        CityDto("c-sochi", "Сочи",             "Краснодарский край"),
-        CityDto("c-ros",   "Ростов-на-Дону",   "Ростовская область"),
-        CityDto("c-nnv",   "Нижний Новгород",  "Нижегородская область"),
-        CityDto("c-sam",   "Самара",           "Самарская область"),
-        CityDto("c-chel",  "Челябинск",        "Челябинская область"),
-        CityDto("c-omsk",  "Омск",             "Омская область"),
-        CityDto("c-krs",   "Красноярск",       "Красноярский край"),
-        CityDto("c-prm",   "Пермь",            "Пермский край"),
-        CityDto("c-vrn",   "Воронеж",          "Воронежская область"),
-        CityDto("c-sar",   "Саратов",          "Саратовская область"),
-        CityDto("c-tym",   "Тюмень",           "Тюменская область"),
-        CityDto("c-vlk",   "Владивосток",      "Приморский край"),
-        CityDto("c-irk",   "Иркутск",          "Иркутская область"),
-        CityDto("c-vlg",   "Волгоград",        "Волгоградская область"),
-        CityDto("c-ast",   "Астрахань",        "Астраханская область"),
-        CityDto("c-eli",   "Элиста",           "Республика Калмыкия")
+        CityDto("c-msk",   "Москва",           SubjectDto("s-msk",  "Москва")),
+        CityDto("c-spb",   "Санкт-Петербург",  SubjectDto("s-spb",  "Санкт-Петербург")),
+        CityDto("c-kzn",   "Казань",           SubjectDto("s-tat",  "Республика Татарстан")),
+        CityDto("c-ufa",   "Уфа",              SubjectDto("s-bash", "Республика Башкортостан")),
+        CityDto("c-ekt",   "Екатеринбург",     SubjectDto("s-svr",  "Свердловская область")),
+        CityDto("c-nvs",   "Новосибирск",      SubjectDto("s-nvs",  "Новосибирская область")),
+        CityDto("c-krd",   "Краснодар",        SubjectDto("s-krd",  "Краснодарский край")),
+        CityDto("c-sochi", "Сочи",             SubjectDto("s-krd",  "Краснодарский край")),
+        CityDto("c-ros",   "Ростов-на-Дону",   SubjectDto("s-ros",  "Ростовская область")),
+        CityDto("c-nnv",   "Нижний Новгород",  SubjectDto("s-nnv",  "Нижегородская область")),
+        CityDto("c-sam",   "Самара",           SubjectDto("s-sam",  "Самарская область")),
+        CityDto("c-chel",  "Челябинск",        SubjectDto("s-chel", "Челябинская область")),
+        CityDto("c-omsk",  "Омск",             SubjectDto("s-omsk", "Омская область")),
+        CityDto("c-krs",   "Красноярск",       SubjectDto("s-krs",  "Красноярский край")),
+        CityDto("c-prm",   "Пермь",            SubjectDto("s-prm",  "Пермский край")),
+        CityDto("c-vrn",   "Воронеж",          SubjectDto("s-vrn",  "Воронежская область")),
+        CityDto("c-sar",   "Саратов",          SubjectDto("s-sar",  "Саратовская область")),
+        CityDto("c-tym",   "Тюмень",           SubjectDto("s-tym",  "Тюменская область")),
+        CityDto("c-vlk",   "Владивосток",      SubjectDto("s-prm2", "Приморский край")),
+        CityDto("c-irk",   "Иркутск",          SubjectDto("s-irk",  "Иркутская область")),
+        CityDto("c-vlg",   "Волгоград",        SubjectDto("s-vlg",  "Волгоградская область")),
+        CityDto("c-ast",   "Астрахань",        SubjectDto("s-ast",  "Астраханская область")),
+        CityDto("c-eli",   "Элиста",           SubjectDto("s-kalm", "Республика Калмыкия"))
     )
 
     override suspend fun getCategories(): List<CategoryDto> =

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeOrderService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FakeOrderService.kt
@@ -1,5 +1,6 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 import kotlinx.coroutines.delay
 
@@ -9,13 +10,19 @@ import kotlinx.coroutines.delay
  */
 class FakeOrderService : OrderService {
 
-    override suspend fun createOrder(eventId: String, authToken: String): OrderDto {
+    override suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto {
         delay(800)
+        val totalPrice = when {
+            request.seatKeys != null -> request.seatKeys.size * 1500
+            request.admissionItems != null -> request.admissionItems.sumOf { it.quantity } * 1500
+            else -> 1500
+        }
         return OrderDto(
             id = "order-fake-${eventId.takeLast(6)}",
             eventId = eventId,
-            status = "PENDING",
-            totalPrice = 1500
+            status = "PENDING_PAYMENT",
+            totalPrice = totalPrice,
+            amount = totalPrice
         )
     }
 
@@ -24,8 +31,9 @@ class FakeOrderService : OrderService {
         return OrderDto(
             id = orderId,
             eventId = "e-fake",
-            status = "CONFIRMED",
+            status = "PAID",
             totalPrice = 1500,
+            amount = 1500,
             ticketId = "ticket-fake-001"
         )
     }
@@ -34,8 +42,9 @@ class FakeOrderService : OrderService {
         return OrderDto(
             id = orderId,
             eventId = "e-fake",
-            status = "CONFIRMED",
-            totalPrice = 1500
+            status = "PAID",
+            totalPrice = 1500,
+            amount = 1500
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
@@ -21,7 +21,7 @@ class FavoriteApiService(
 ) : FavoriteService {
 
     override suspend fun add(eventId: String, token: String) {
-        httpClient.post("$baseUrl/api/favorites") {
+        httpClient.post("$baseUrl/api/v1/favorites") {
             bearerAuth(token)
             contentType(ContentType.Application.Json)
             setBody(AddFavoriteRequest(eventId))
@@ -29,13 +29,13 @@ class FavoriteApiService(
     }
 
     override suspend fun remove(eventId: String, token: String) {
-        httpClient.delete("$baseUrl/api/favorites/$eventId") {
+        httpClient.delete("$baseUrl/api/v1/favorites/$eventId") {
             bearerAuth(token)
         }
     }
 
     override suspend fun list(token: String): List<EventDto> =
-        httpClient.get("$baseUrl/api/favorites") {
+        httpClient.get("$baseUrl/api/v1/favorites") {
             bearerAuth(token)
         }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/GeoApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/GeoApiService.kt
@@ -12,8 +12,8 @@ class GeoApiService(
 ) : GeoService {
 
     override suspend fun getCities(): List<CityDto> =
-        httpClient.get("$baseUrl/api/geo/cities").body()
+        httpClient.get("$baseUrl/api/v1/geo/cities").body()
 
     override suspend fun getCategories(): List<CategoryDto> =
-        httpClient.get("$baseUrl/api/categories").body()
+        httpClient.get("$baseUrl/api/v1/categories").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderApiService.kt
@@ -1,29 +1,35 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 
 class OrderApiService(
     private val httpClient: HttpClient,
     private val baseUrl: String
 ) : OrderService {
 
-    override suspend fun createOrder(eventId: String, authToken: String): OrderDto =
-        httpClient.post("$baseUrl/api/events/$eventId/orders") {
+    override suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto =
+        httpClient.post("$baseUrl/api/v1/events/$eventId/orders") {
             bearerAuth(authToken)
+            contentType(ContentType.Application.Json)
+            setBody(request)
         }.body()
 
     override suspend fun confirmPayment(orderId: String, authToken: String): OrderDto =
-        httpClient.post("$baseUrl/api/orders/$orderId/confirm-payment") {
+        httpClient.post("$baseUrl/api/v1/orders/$orderId/confirm-payment") {
             bearerAuth(authToken)
         }.body()
 
     override suspend fun getOrder(orderId: String, authToken: String): OrderDto =
-        httpClient.get("$baseUrl/api/orders/$orderId") {
+        httpClient.get("$baseUrl/api/v1/orders/$orderId") {
             bearerAuth(authToken)
         }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderService.kt
@@ -1,9 +1,10 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 
 interface OrderService {
-    suspend fun createOrder(eventId: String, authToken: String): OrderDto
+    suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto
     suspend fun confirmPayment(orderId: String, authToken: String): OrderDto
     suspend fun getOrder(orderId: String, authToken: String): OrderDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerApiService.kt
@@ -14,7 +14,7 @@ class ScannerApiService(
 ) : ScannerService {
 
     override suspend fun getMyOrgEvents(authToken: String?): List<OrgEventItem> =
-        httpClient.get("$baseUrl/api/my/organization/events") {
+        httpClient.get("$baseUrl/api/v1/my/organization/events") {
             authToken?.let { header("Authorization", "Bearer $it") }
         }.body()
 
@@ -23,7 +23,7 @@ class ScannerApiService(
         ticketId: String,
         authToken: String?
     ): TicketValidationResponse =
-        httpClient.post("$baseUrl/api/events/$eventId/tickets/$ticketId/validate") {
+        httpClient.post("$baseUrl/api/v1/events/$eventId/tickets/$ticketId/validate") {
             authToken?.let { header("Authorization", "Bearer $it") }
         }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketApiService.kt
@@ -12,7 +12,7 @@ class TicketApiService(
 ) : TicketService {
 
     override suspend fun getMyTickets(authToken: String): List<TicketDto> =
-        httpClient.get("$baseUrl/api/tickets/me") {
+        httpClient.get("$baseUrl/api/v1/tickets/me") {
             bearerAuth(authToken)
         }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/GeoDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/GeoDto.kt
@@ -5,6 +5,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CityDto(
     val id: String,
-    val name: String,
-    val region: String? = null
-)
+    val label: String,
+    val subject: SubjectDto? = null
+) {
+    val name: String get() = label
+    val region: String? get() = subject?.label
+}
+
+@Serializable
+data class SubjectDto(val id: String, val label: String)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrderDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrderDto.kt
@@ -6,7 +6,27 @@ import kotlinx.serialization.Serializable
 data class OrderDto(
     val id: String,
     val eventId: String,
-    val status: String, // PENDING, CONFIRMED, CANCELLED
-    val totalPrice: Int,
+    val status: String, // PENDING_PAYMENT, PAID, PAYMENT_FAILED, EXPIRED
+    val totalPrice: Int = 0,
+    val amount: Int? = null,
     val ticketId: String? = null
+)
+
+@Serializable
+data class CreateOrderRequestDto(
+    val seatKeys: List<SeatKeyRequestDto>? = null,
+    val admissionItems: List<AdmissionInventoryItemRequestDto>? = null
+)
+
+@Serializable
+data class SeatKeyRequestDto(
+    val sectionKey: String,
+    val rowKey: String,
+    val seatKey: String
+)
+
+@Serializable
+data class AdmissionInventoryItemRequestDto(
+    val ticketTypeId: String,
+    val quantity: Int
 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
@@ -13,8 +13,8 @@ data class OrgEventItem(
 data class TicketValidationResponse(
     val status: String,
     val holderName: String? = null,
-    val seat: String? = null,
+    @kotlinx.serialization.SerialName("seatInfo") val seat: String? = null,
     val usedAt: String? = null,
     val ticketEventLabel: String? = null,
-    val scannedEventLabel: String? = null
+    @kotlinx.serialization.SerialName("eventLabel") val scannedEventLabel: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
@@ -158,9 +158,9 @@ private fun CityCard(city: CityDto, selected: Boolean, onClick: () -> Unit) {
                 style = MaterialTheme.typography.bodyLarge,
                 color = textColor
             )
-            if (city.region != null) {
+            city.region?.let { region ->
                 Text(
-                    text = city.region,
+                    text = region,
                     style = MaterialTheme.typography.bodySmall,
                     color = regionColor
                 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +44,9 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.LoginScreen
+import kotlinx.coroutines.launch
 import com.karrad.ticketsclient.ui.navigation.AboutScreen
 import com.karrad.ticketsclient.ui.navigation.EditProfileScreen
 import com.karrad.ticketsclient.ui.navigation.FavoritesScreen
@@ -56,6 +59,7 @@ fun ProfileScreen() {
     // EditProfileScreen открывается поверх табов
     val rootNavigator = navigator.parent ?: navigator
 
+    val scope = rememberCoroutineScope()
     var name by remember { mutableStateOf(AppSession.userName) }
     var phone by remember { mutableStateOf(AppSession.userPhone) }
 
@@ -90,8 +94,14 @@ fun ProfileScreen() {
                     .clip(CircleShape)
                     .background(MaterialTheme.colorScheme.primary)
                     .clickable {
+                        val token = AppSession.authToken
                         AppSession.logout()
                         rootNavigator.replaceAll(LoginScreen)
+                        if (token != null) {
+                            scope.launch {
+                                runCatching { AppContainer.authService.logout(token) }
+                            }
+                        }
                     },
                 contentAlignment = Alignment.Center
             ) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
@@ -60,7 +60,9 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import androidx.compose.runtime.LaunchedEffect
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SeatKeyRequestDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.OrderConfirmScreen
@@ -69,7 +71,7 @@ import kotlinx.coroutines.launch
 
 // ─── Модели ────────────────────────────────────────────────────────────────────
 
-private data class Seat(val row: Int, val col: Int, val available: Boolean, val price: Int = 0)
+private data class Seat(val sectionKey: String, val rowKey: String, val seatKey: String, val row: Int, val col: Int, val available: Boolean, val price: Int = 0)
 
 private val SESSION_TIMES = listOf("13:00", "17:00", "23:00")
 
@@ -81,7 +83,7 @@ private fun SeatMapDto.toSeats(): List<Seat> {
     sections.forEach { section ->
         section.rows.forEachIndexed { rowIdx, row ->
             row.seats.forEachIndexed { colIdx, seat ->
-                result += Seat(rowIdx, colIdx, seat.available, seat.price)
+                result += Seat(section.key, row.key, seat.key, rowIdx, colIdx, seat.available, seat.price)
             }
         }
     }
@@ -312,7 +314,16 @@ fun SeatMapScreen(eventId: String) {
                                     try {
                                         val order = AppContainer.orderService.createOrder(
                                             eventId = eventId,
-                                            authToken = AppSession.authToken ?: ""
+                                            authToken = AppSession.authToken ?: "",
+                                            request = CreateOrderRequestDto(
+                                                seatKeys = selectedSeats.map { seat ->
+                                                    SeatKeyRequestDto(
+                                                        sectionKey = seat.sectionKey,
+                                                        rowKey = seat.rowKey,
+                                                        seatKey = seat.seatKey
+                                                    )
+                                                }
+                                            )
                                         )
                                         navigator.push(
                                             OrderConfirmScreen(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.AdmissionInventoryItemRequestDto
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.OrderConfirmScreen
@@ -264,7 +266,17 @@ fun TicketTypeScreen(eventId: String) {
                                 try {
                                     val order = AppContainer.orderService.createOrder(
                                         eventId = eventId,
-                                        authToken = AppSession.authToken ?: ""
+                                        authToken = AppSession.authToken ?: "",
+                                        request = CreateOrderRequestDto(
+                                            admissionItems = quantities
+                                                .filterValues { it > 0 }
+                                                .map { (ticketTypeId, quantity) ->
+                                                    AdmissionInventoryItemRequestDto(
+                                                        ticketTypeId = ticketTypeId,
+                                                        quantity = quantity
+                                                    )
+                                                }
+                                        )
                                     )
                                     navigator.push(
                                         OrderConfirmScreen(

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/data/api/FakeOrderServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/data/api/FakeOrderServiceTest.kt
@@ -1,5 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.AdmissionInventoryItemRequestDto
+import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,41 +11,44 @@ import kotlin.test.assertTrue
 class FakeOrderServiceTest {
 
     private val service = FakeOrderService()
+    private val request = CreateOrderRequestDto(
+        admissionItems = listOf(AdmissionInventoryItemRequestDto(ticketTypeId = "tt-general", quantity = 1))
+    )
 
     @Test
     fun `createOrder returns order with correct eventId`() = runTest {
-        val order = service.createOrder("evt-001", "token")
+        val order = service.createOrder("evt-001", "token", request)
         assertEquals("evt-001", order.eventId)
     }
 
     @Test
-    fun `createOrder returns PENDING status`() = runTest {
-        val order = service.createOrder("evt-001", "token")
-        assertEquals("PENDING", order.status)
+    fun `createOrder returns pending payment status`() = runTest {
+        val order = service.createOrder("evt-001", "token", request)
+        assertEquals("PENDING_PAYMENT", order.status)
     }
 
     @Test
     fun `createOrder returns non-blank orderId`() = runTest {
-        val order = service.createOrder("evt-001", "token")
+        val order = service.createOrder("evt-001", "token", request)
         assertTrue(order.id.isNotBlank())
     }
 
     @Test
     fun `createOrder returns positive totalPrice`() = runTest {
-        val order = service.createOrder("evt-001", "token")
+        val order = service.createOrder("evt-001", "token", request)
         assertTrue(order.totalPrice > 0)
     }
 
     @Test
-    fun `confirmPayment returns CONFIRMED status`() = runTest {
-        val created = service.createOrder("evt-001", "token")
+    fun `confirmPayment returns paid status`() = runTest {
+        val created = service.createOrder("evt-001", "token", request)
         val confirmed = service.confirmPayment(created.id, "token")
-        assertEquals("CONFIRMED", confirmed.status)
+        assertEquals("PAID", confirmed.status)
     }
 
     @Test
     fun `confirmPayment returns ticketId`() = runTest {
-        val created = service.createOrder("evt-001", "token")
+        val created = service.createOrder("evt-001", "token", request)
         val confirmed = service.confirmPayment(created.id, "token")
         assertNotNull(confirmed.ticketId)
         assertTrue(confirmed.ticketId.isNotBlank())


### PR DESCRIPTION
Closes #115, #116, #117

## #115 — CityDto (name/region → label/subject)
`GET /api/v1/geo/cities` возвращает `label` и `subject: {id, label}`.
`CityDto` теперь имеет поля `label: String` и `subject: SubjectDto?`.
Computed properties `name` и `region` сохраняют совместимость с `CitySelectionScreen`.

## #116 — TicketValidationResponse (несовпадение имён полей)
- `@SerialName("seatInfo") val seat` — бэк возвращает `seatInfo`, не `seat`
- `@SerialName("eventLabel") val scannedEventLabel` — бэк возвращает `eventLabel` для метки отсканированного события

## #117 — Logout не инвалидировал серверный токен
Добавлен `suspend fun logout(token: String)` в `AuthService`.
`AuthApiService` делает `POST /auth/logout` с Bearer-токеном.
`ProfileScreen`: токен сохраняется до `AppSession.logout()`, затем API вызывается fire-and-forget.

## Тесты
116 unit-тестов — BUILD SUCCESS