### PR TITLE
feat(#121,#122,#123): экраны управления организацией и ограничение сканера

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.store.SessionSnapshot
 import com.karrad.ticketsclient.data.store.TokenStore
 
@@ -45,6 +46,9 @@ object AppSession {
 
     var userRole: String = "USER"
 
+    // Членство в организации — загружается после входа в MainScreen
+    var orgMembership: OrgMembershipDto? by mutableStateOf(null)
+
     fun login(
         token: String,
         userId: String,
@@ -85,6 +89,7 @@ object AppSession {
         userAvatarUrl = null
         cachedEvents = emptyList()
         cachedTickets = emptyList()
+        orgMembership = null
         _favorites.clear()
         TokenStore.clear()
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
@@ -1,0 +1,56 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.AddMemberRequest
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+import com.karrad.ticketsclient.data.api.dto.UpdateMemberRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+
+class OrgMemberApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : OrgMemberService {
+
+    override suspend fun getMyMembership(authToken: String): OrgMembershipDto? {
+        val response = httpClient.get("$baseUrl/api/v1/my/organization/membership") {
+            header("Authorization", "Bearer $authToken")
+        }
+        return if (response.status == HttpStatusCode.NotFound) null
+        else response.body()
+    }
+
+    override suspend fun listMembers(authToken: String): List<OrgMemberDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/members") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+
+    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto =
+        httpClient.post("$baseUrl/api/v1/my/organization/members") {
+            header("Authorization", "Bearer $authToken")
+            contentType(ContentType.Application.Json)
+            setBody(AddMemberRequest(userId = userId, role = role, venueId = venueId))
+        }.body()
+
+    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto =
+        httpClient.put("$baseUrl/api/v1/my/organization/members/$memberId") {
+            header("Authorization", "Bearer $authToken")
+            contentType(ContentType.Application.Json)
+            setBody(UpdateMemberRequest(role = role, venueId = venueId))
+        }.body()
+
+    override suspend fun deleteMember(authToken: String, memberId: String) {
+        httpClient.delete("$baseUrl/api/v1/my/organization/members/$memberId") {
+            header("Authorization", "Bearer $authToken")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
@@ -1,0 +1,21 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+
+interface OrgMemberService {
+    /** Возвращает членство текущего пользователя в организации, или null если не состоит. */
+    suspend fun getMyMembership(authToken: String): OrgMembershipDto?
+
+    /** Список членов организации (требует OWNER или MANAGER). */
+    suspend fun listMembers(authToken: String): List<OrgMemberDto>
+
+    /** Добавить участника (OWNER — любую роль; MANAGER — только STAFF). */
+    suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto
+
+    /** Обновить роль/venue участника (только OWNER). */
+    suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto
+
+    /** Удалить участника (OWNER — любого; MANAGER — только STAFF). */
+    suspend fun deleteMember(authToken: String, memberId: String)
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
@@ -1,0 +1,33 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrgMembershipDto(
+    val memberId: String,
+    val organizationId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class OrgMemberDto(
+    val id: String,
+    val organizationId: String,
+    val userId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class AddMemberRequest(
+    val userId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class UpdateMemberRequest(
+    val role: String,
+    val venueId: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -10,6 +10,8 @@ import com.karrad.ticketsclient.data.api.FavoriteApiService
 import com.karrad.ticketsclient.data.api.FavoriteService
 import com.karrad.ticketsclient.data.api.GeoApiService
 import com.karrad.ticketsclient.data.api.GeoService
+import com.karrad.ticketsclient.data.api.OrgMemberApiService
+import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.OrderApiService
 import com.karrad.ticketsclient.data.api.OrderService
 import com.karrad.ticketsclient.data.api.ProfileApiService
@@ -56,6 +58,9 @@ object AppContainer {
     lateinit var favoriteService: FavoriteService
         private set
 
+    lateinit var orgMemberService: OrgMemberService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
@@ -70,7 +75,8 @@ object AppContainer {
         eventService: EventService,
         geoService: GeoService,
         profileService: ProfileService,
-        favoriteService: FavoriteService
+        favoriteService: FavoriteService,
+        orgMemberService: OrgMemberService
     ) {
         this.isMock = isMock
         this.httpClient = httpClient
@@ -83,6 +89,7 @@ object AppContainer {
         this.geoService = geoService
         this.profileService = profileService
         this.favoriteService = favoriteService
+        this.orgMemberService = orgMemberService
     }
 }
 
@@ -99,6 +106,7 @@ fun AppContainer.initReal(baseUrl: String) {
         eventService = EventApiService(client, baseUrl),
         geoService = GeoApiService(client, baseUrl),
         profileService = ProfileApiService(client, baseUrl),
-        favoriteService = FavoriteApiService(client, baseUrl)
+        favoriteService = FavoriteApiService(client, baseUrl),
+        orgMemberService = OrgMemberApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -107,3 +107,15 @@ object AboutScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.profile.AboutScreen()
 }
+
+// Org management (OWNER)
+object OrgManagementScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.OrgManagementScreen()
+}
+
+// Member management (MANAGER)
+object MemberManagementScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.MemberManagementScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
@@ -58,12 +58,15 @@ fun MainScreen() {
 
     LaunchedEffect(Unit) {
         if (!AppContainer.isMock) {
-            showScanner = try {
-                AppContainer.scannerService.getMyOrgEvents(AppSession.authToken).isNotEmpty()
+            val token = AppSession.authToken ?: return@LaunchedEffect
+            val membership = try {
+                AppContainer.orgMemberService.getMyMembership(token)
             } catch (e: Exception) {
-                println("MainScreen: не удалось проверить доступ к сканеру — ${e.message}")
-                false
+                println("MainScreen: не удалось получить членство — ${e.message}")
+                null
             }
+            AppSession.orgMembership = membership
+            showScanner = membership != null
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -1,0 +1,187 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun MemberManagementScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var addUserId by remember { mutableStateOf("") }
+    var addVenueId by remember { mutableStateOf("") }
+
+    fun loadMembers() {
+        scope.launch {
+            isLoading = true
+            error = null
+            val token = AppSession.authToken ?: return@launch
+            try {
+                // MANAGER видит только STAFF
+                members = AppContainer.orgMemberService.listMembers(token)
+                    .filter { it.role == "STAFF" }
+            } catch (e: Exception) {
+                error = e.message
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) { loadMembers() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Сотрудники",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить сотрудника")
+            }
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    "Сотрудников пока нет",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(members) { member ->
+                    MemberRow(
+                        member = member,
+                        canDelete = true,
+                        onDelete = {
+                            scope.launch {
+                                val token = AppSession.authToken ?: return@launch
+                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                loadMembers()
+                            }
+                        }
+                    )
+                }
+                item { Spacer(Modifier.height(96.dp)) }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("Добавить сотрудника (STAFF)") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = addUserId,
+                        onValueChange = { addUserId = it },
+                        label = { Text("UUID пользователя") },
+                        singleLine = true
+                    )
+                    OutlinedTextField(
+                        value = addVenueId,
+                        onValueChange = { addVenueId = it },
+                        label = { Text("UUID площадки") },
+                        singleLine = true
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    scope.launch {
+                        val token = AppSession.authToken ?: return@launch
+                        runCatching {
+                            AppContainer.orgMemberService.addMember(
+                                authToken = token,
+                                userId = addUserId.trim(),
+                                role = "STAFF",
+                                venueId = addVenueId.trim().ifBlank { null }
+                            )
+                        }
+                        showAddDialog = false
+                        addUserId = ""
+                        addVenueId = ""
+                        loadMembers()
+                    }
+                }) { Text("Добавить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+            }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -1,0 +1,281 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrgManagementScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    // Add member dialog state
+    var showAddDialog by remember { mutableStateOf(false) }
+    var addUserId by remember { mutableStateOf("") }
+    var addRole by remember { mutableStateOf("MANAGER") }
+    var addVenueId by remember { mutableStateOf("") }
+    var roleMenuExpanded by remember { mutableStateOf(false) }
+
+    fun loadMembers() {
+        scope.launch {
+            isLoading = true
+            error = null
+            val token = AppSession.authToken ?: return@launch
+            try {
+                members = AppContainer.orgMemberService.listMembers(token)
+            } catch (e: Exception) {
+                error = e.message
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) { loadMembers() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        // Toolbar
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Управление организацией",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить участника")
+            }
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(members) { member ->
+                    MemberRow(
+                        member = member,
+                        canDelete = true,
+                        onDelete = {
+                            scope.launch {
+                                val token = AppSession.authToken ?: return@launch
+                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                loadMembers()
+                            }
+                        }
+                    )
+                }
+                item { Spacer(Modifier.height(96.dp)) }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("Добавить участника") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = addUserId,
+                        onValueChange = { addUserId = it },
+                        label = { Text("UUID пользователя") },
+                        singleLine = true
+                    )
+                    Box {
+                        OutlinedTextField(
+                            value = addRole,
+                            onValueChange = {},
+                            label = { Text("Роль") },
+                            readOnly = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        TextButton(
+                            onClick = { roleMenuExpanded = true },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text(addRole) }
+                        DropdownMenu(
+                            expanded = roleMenuExpanded,
+                            onDismissRequest = { roleMenuExpanded = false }
+                        ) {
+                            listOf("MANAGER", "STAFF").forEach { role ->
+                                DropdownMenuItem(
+                                    text = { Text(role) },
+                                    onClick = { addRole = role; roleMenuExpanded = false }
+                                )
+                            }
+                        }
+                    }
+                    if (addRole == "STAFF") {
+                        OutlinedTextField(
+                            value = addVenueId,
+                            onValueChange = { addVenueId = it },
+                            label = { Text("UUID площадки") },
+                            singleLine = true
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    scope.launch {
+                        val token = AppSession.authToken ?: return@launch
+                        runCatching {
+                            AppContainer.orgMemberService.addMember(
+                                authToken = token,
+                                userId = addUserId.trim(),
+                                role = addRole,
+                                venueId = addVenueId.trim().ifBlank { null }
+                            )
+                        }
+                        showAddDialog = false
+                        addUserId = ""
+                        addRole = "MANAGER"
+                        addVenueId = ""
+                        loadMembers()
+                    }
+                }) { Text("Добавить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+            }
+        )
+    }
+}
+
+@Composable
+fun MemberRow(
+    member: OrgMemberDto,
+    canDelete: Boolean,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                Icons.Outlined.Person,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = member.role,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                text = member.userId,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1
+            )
+            if (member.venueId != null) {
+                Text(
+                    text = "Площадка: ${member.venueId}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+            }
+        }
+        if (canDelete) {
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Outlined.Delete,
+                    contentDescription = "Удалить",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
@@ -51,6 +51,8 @@ import com.karrad.ticketsclient.ui.navigation.AboutScreen
 import com.karrad.ticketsclient.ui.navigation.EditProfileScreen
 import com.karrad.ticketsclient.ui.navigation.FavoritesScreen
 import com.karrad.ticketsclient.ui.navigation.InterestsScreen
+import com.karrad.ticketsclient.ui.navigation.MemberManagementScreen
+import com.karrad.ticketsclient.ui.navigation.OrgManagementScreen
 import com.karrad.ticketsclient.ui.navigation.SupportScreen
 
 @Composable
@@ -154,6 +156,23 @@ fun ProfileScreen() {
         Spacer(Modifier.height(16.dp))
 
         // ─── Меню ────────────────────────────────────────────────────────────
+        val membership = AppSession.orgMembership
+        if (membership != null) {
+            MenuCard {
+                when (membership.role) {
+                    "OWNER" -> MenuItem(
+                        label = "Управление организацией",
+                        onClick = { rootNavigator.push(OrgManagementScreen) }
+                    )
+                    "MANAGER" -> MenuItem(
+                        label = "Сотрудники",
+                        onClick = { rootNavigator.push(MemberManagementScreen) }
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+
         MenuCard {
             MenuItem(label = "Избранное", onClick = { rootNavigator.push(FavoritesScreen) })
             MenuDivider()

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -8,6 +8,7 @@ import com.karrad.ticketsclient.data.api.FakeGeoService
 import com.karrad.ticketsclient.data.api.FakeOrderService
 import com.karrad.ticketsclient.data.api.FakeProfileService
 import com.karrad.ticketsclient.data.api.FakeScannerService
+import com.karrad.ticketsclient.data.api.FakeOrgMemberService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
@@ -25,6 +26,7 @@ fun initContainer(baseUrl: String) {
         eventService = FakeEventService(),
         geoService = FakeGeoService(),
         profileService = FakeProfileService(),
-        favoriteService = FakeFavoriteService()
+        favoriteService = FakeFavoriteService(),
+        orgMemberService = FakeOrgMemberService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
@@ -1,0 +1,61 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+
+class FakeOrgMemberService : OrgMemberService {
+
+    private val members = mutableListOf(
+        OrgMemberDto(
+            id = "member-owner-1",
+            organizationId = "org-1",
+            userId = "user-owner",
+            role = "OWNER"
+        ),
+        OrgMemberDto(
+            id = "member-mgr-1",
+            organizationId = "org-1",
+            userId = "user-mgr",
+            role = "MANAGER"
+        ),
+        OrgMemberDto(
+            id = "member-staff-1",
+            organizationId = "org-1",
+            userId = "user-staff",
+            role = "STAFF",
+            venueId = "venue-1"
+        )
+    )
+
+    override suspend fun getMyMembership(authToken: String): OrgMembershipDto =
+        OrgMembershipDto(
+            memberId = "member-owner-1",
+            organizationId = "org-1",
+            role = "OWNER"
+        )
+
+    override suspend fun listMembers(authToken: String): List<OrgMemberDto> = members.toList()
+
+    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto {
+        val member = OrgMemberDto(
+            id = "member-new-${members.size}",
+            organizationId = "org-1",
+            userId = userId,
+            role = role,
+            venueId = venueId
+        )
+        members.add(member)
+        return member
+    }
+
+    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto {
+        val index = members.indexOfFirst { it.id == memberId }
+        val updated = members[index].copy(role = role, venueId = venueId)
+        members[index] = updated
+        return updated
+    }
+
+    override suspend fun deleteMember(authToken: String, memberId: String) {
+        members.removeAll { it.id == memberId }
+    }
+}


### PR DESCRIPTION
## Summary

- **#121** — `OrgManagementScreen`: OWNER видит список всех членов организации, может добавлять MANAGER/STAFF и удалять любого
- **#122** — `MemberManagementScreen`: MANAGER видит только STAFF-сотрудников, может добавлять/удалять
- **#123** — Ограничение сканера по роли: сканер виден только членам организации; ограничение STAFF по venueId реализовано на бэкенде (PR ticketsbackend #264)
- `OrgMemberService` / `OrgMemberApiService` — CRUD для `/api/v1/my/organization/members`
- `AppSession.orgMembership` — загружается в `MainScreen`, используется `ProfileScreen` для показа нужного пункта меню
- `FakeOrgMemberService` — мок-реализация в `src/mock/` для разработки

## Depends on

- ticketsbackend PR #264 — роль STAFF, endpoint `/my/organization/membership`, CRUD members

## Test plan

- [x] `testMockDebugUnitTest` — все тесты зелёные
- [x] `compileMockDebugKotlinAndroid` — без ошибок
- [x] `compileProdDebugKotlinAndroid` — без ошибок

Closes #121
Closes #122
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)