### PR TITLE
feat(#124): venue access grant UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.store.SessionSnapshot
 import com.karrad.ticketsclient.data.store.TokenStore
 
@@ -45,6 +46,9 @@ object AppSession {
 
     var userRole: String = "USER"
 
+    // Членство в организации — загружается после входа в MainScreen
+    var orgMembership: OrgMembershipDto? by mutableStateOf(null)
+
     fun login(
         token: String,
         userId: String,
@@ -85,6 +89,7 @@ object AppSession {
         userAvatarUrl = null
         cachedEvents = emptyList()
         cachedTickets = emptyList()
+        orgMembership = null
         _favorites.clear()
         TokenStore.clear()
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
@@ -1,0 +1,56 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.AddMemberRequest
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+import com.karrad.ticketsclient.data.api.dto.UpdateMemberRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+
+class OrgMemberApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : OrgMemberService {
+
+    override suspend fun getMyMembership(authToken: String): OrgMembershipDto? {
+        val response = httpClient.get("$baseUrl/api/v1/my/organization/membership") {
+            header("Authorization", "Bearer $authToken")
+        }
+        return if (response.status == HttpStatusCode.NotFound) null
+        else response.body()
+    }
+
+    override suspend fun listMembers(authToken: String): List<OrgMemberDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/members") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+
+    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto =
+        httpClient.post("$baseUrl/api/v1/my/organization/members") {
+            header("Authorization", "Bearer $authToken")
+            contentType(ContentType.Application.Json)
+            setBody(AddMemberRequest(userId = userId, role = role, venueId = venueId))
+        }.body()
+
+    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto =
+        httpClient.put("$baseUrl/api/v1/my/organization/members/$memberId") {
+            header("Authorization", "Bearer $authToken")
+            contentType(ContentType.Application.Json)
+            setBody(UpdateMemberRequest(role = role, venueId = venueId))
+        }.body()
+
+    override suspend fun deleteMember(authToken: String, memberId: String) {
+        httpClient.delete("$baseUrl/api/v1/my/organization/members/$memberId") {
+            header("Authorization", "Bearer $authToken")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
@@ -1,0 +1,21 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+
+interface OrgMemberService {
+    /** Возвращает членство текущего пользователя в организации, или null если не состоит. */
+    suspend fun getMyMembership(authToken: String): OrgMembershipDto?
+
+    /** Список членов организации (требует OWNER или MANAGER). */
+    suspend fun listMembers(authToken: String): List<OrgMemberDto>
+
+    /** Добавить участника (OWNER — любую роль; MANAGER — только STAFF). */
+    suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto
+
+    /** Обновить роль/venue участника (только OWNER). */
+    suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto
+
+    /** Удалить участника (OWNER — любого; MANAGER — только STAFF). */
+    suspend fun deleteMember(authToken: String, memberId: String)
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantApiService.kt
@@ -1,0 +1,45 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.RequestVenueAccessRequest
+import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+
+class VenueAccessGrantApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : VenueAccessGrantService {
+
+    override suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/incoming-access-requests") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+
+    override suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/outgoing-access-requests") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+
+    override suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests") {
+            header("Authorization", "Bearer $authToken")
+            contentType(ContentType.Application.Json)
+            setBody(RequestVenueAccessRequest(requestingOrgId = requestingOrgId))
+        }.body()
+
+    override suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/approve") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+
+    override suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/reject") {
+            header("Authorization", "Bearer $authToken")
+        }.body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantService.kt
@@ -1,0 +1,20 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
+
+interface VenueAccessGrantService {
+    /** Входящие запросы на аренду площадок организации (для OWNER). */
+    suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto>
+
+    /** Исходящие запросы на аренду чужих площадок (для OWNER/MANAGER). */
+    suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto>
+
+    /** Отправить запрос на аренду площадки. */
+    suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto
+
+    /** Одобрить входящий запрос. */
+    suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto
+
+    /** Отклонить входящий запрос. */
+    suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
@@ -1,0 +1,33 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OrgMembershipDto(
+    val memberId: String,
+    val organizationId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class OrgMemberDto(
+    val id: String,
+    val organizationId: String,
+    val userId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class AddMemberRequest(
+    val userId: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class UpdateMemberRequest(
+    val role: String,
+    val venueId: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueAccessGrantDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueAccessGrantDto.kt
@@ -1,0 +1,18 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VenueAccessGrantDto(
+    val id: String,
+    val venueId: String,
+    val requestingOrgId: String,
+    val status: String,
+    val createdAt: String,
+    val decidedAt: String? = null
+)
+
+@Serializable
+data class RequestVenueAccessRequest(
+    val requestingOrgId: String
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -20,6 +20,8 @@ import com.karrad.ticketsclient.data.api.ScannerApiService
 import com.karrad.ticketsclient.data.api.ScannerService
 import com.karrad.ticketsclient.data.api.TicketApiService
 import com.karrad.ticketsclient.data.api.TicketService
+import com.karrad.ticketsclient.data.api.VenueAccessGrantApiService
+import com.karrad.ticketsclient.data.api.VenueAccessGrantService
 import com.karrad.ticketsclient.data.api.createHttpClient
 
 /**
@@ -61,6 +63,9 @@ object AppContainer {
     lateinit var orgMemberService: OrgMemberService
         private set
 
+    lateinit var venueAccessGrantService: VenueAccessGrantService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
@@ -76,7 +81,8 @@ object AppContainer {
         geoService: GeoService,
         profileService: ProfileService,
         favoriteService: FavoriteService,
-        orgMemberService: OrgMemberService
+        orgMemberService: OrgMemberService,
+        venueAccessGrantService: VenueAccessGrantService
     ) {
         this.isMock = isMock
         this.httpClient = httpClient
@@ -90,6 +96,7 @@ object AppContainer {
         this.profileService = profileService
         this.favoriteService = favoriteService
         this.orgMemberService = orgMemberService
+        this.venueAccessGrantService = venueAccessGrantService
     }
 }
 
@@ -107,6 +114,7 @@ fun AppContainer.initReal(baseUrl: String) {
         geoService = GeoApiService(client, baseUrl),
         profileService = ProfileApiService(client, baseUrl),
         favoriteService = FavoriteApiService(client, baseUrl),
-        orgMemberService = OrgMemberApiService(client, baseUrl)
+        orgMemberService = OrgMemberApiService(client, baseUrl),
+        venueAccessGrantService = VenueAccessGrantApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -10,6 +10,8 @@ import com.karrad.ticketsclient.data.api.FavoriteApiService
 import com.karrad.ticketsclient.data.api.FavoriteService
 import com.karrad.ticketsclient.data.api.GeoApiService
 import com.karrad.ticketsclient.data.api.GeoService
+import com.karrad.ticketsclient.data.api.OrgMemberApiService
+import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.OrderApiService
 import com.karrad.ticketsclient.data.api.OrderService
 import com.karrad.ticketsclient.data.api.ProfileApiService
@@ -56,6 +58,9 @@ object AppContainer {
     lateinit var favoriteService: FavoriteService
         private set
 
+    lateinit var orgMemberService: OrgMemberService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
@@ -70,7 +75,8 @@ object AppContainer {
         eventService: EventService,
         geoService: GeoService,
         profileService: ProfileService,
-        favoriteService: FavoriteService
+        favoriteService: FavoriteService,
+        orgMemberService: OrgMemberService
     ) {
         this.isMock = isMock
         this.httpClient = httpClient
@@ -83,6 +89,7 @@ object AppContainer {
         this.geoService = geoService
         this.profileService = profileService
         this.favoriteService = favoriteService
+        this.orgMemberService = orgMemberService
     }
 }
 
@@ -99,6 +106,7 @@ fun AppContainer.initReal(baseUrl: String) {
         eventService = EventApiService(client, baseUrl),
         geoService = GeoApiService(client, baseUrl),
         profileService = ProfileApiService(client, baseUrl),
-        favoriteService = FavoriteApiService(client, baseUrl)
+        favoriteService = FavoriteApiService(client, baseUrl),
+        orgMemberService = OrgMemberApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -107,3 +107,15 @@ object AboutScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.profile.AboutScreen()
 }
+
+// Org management (OWNER)
+object OrgManagementScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.OrgManagementScreen()
+}
+
+// Member management (MANAGER)
+object MemberManagementScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.MemberManagementScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -119,3 +119,9 @@ object MemberManagementScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.MemberManagementScreen()
 }
+
+// Venue access grants (OWNER)
+object VenueAccessScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueAccessScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
@@ -58,12 +58,15 @@ fun MainScreen() {
 
     LaunchedEffect(Unit) {
         if (!AppContainer.isMock) {
-            showScanner = try {
-                AppContainer.scannerService.getMyOrgEvents(AppSession.authToken).isNotEmpty()
+            val token = AppSession.authToken ?: return@LaunchedEffect
+            val membership = try {
+                AppContainer.orgMemberService.getMyMembership(token)
             } catch (e: Exception) {
-                println("MainScreen: не удалось проверить доступ к сканеру — ${e.message}")
-                false
+                println("MainScreen: не удалось получить членство — ${e.message}")
+                null
             }
+            AppSession.orgMembership = membership
+            showScanner = membership != null
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -1,0 +1,187 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun MemberManagementScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var addUserId by remember { mutableStateOf("") }
+    var addVenueId by remember { mutableStateOf("") }
+
+    fun loadMembers() {
+        scope.launch {
+            isLoading = true
+            error = null
+            val token = AppSession.authToken ?: return@launch
+            try {
+                // MANAGER видит только STAFF
+                members = AppContainer.orgMemberService.listMembers(token)
+                    .filter { it.role == "STAFF" }
+            } catch (e: Exception) {
+                error = e.message
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) { loadMembers() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Сотрудники",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить сотрудника")
+            }
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    "Сотрудников пока нет",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(members) { member ->
+                    MemberRow(
+                        member = member,
+                        canDelete = true,
+                        onDelete = {
+                            scope.launch {
+                                val token = AppSession.authToken ?: return@launch
+                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                loadMembers()
+                            }
+                        }
+                    )
+                }
+                item { Spacer(Modifier.height(96.dp)) }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("Добавить сотрудника (STAFF)") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = addUserId,
+                        onValueChange = { addUserId = it },
+                        label = { Text("UUID пользователя") },
+                        singleLine = true
+                    )
+                    OutlinedTextField(
+                        value = addVenueId,
+                        onValueChange = { addVenueId = it },
+                        label = { Text("UUID площадки") },
+                        singleLine = true
+                    )
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    scope.launch {
+                        val token = AppSession.authToken ?: return@launch
+                        runCatching {
+                            AppContainer.orgMemberService.addMember(
+                                authToken = token,
+                                userId = addUserId.trim(),
+                                role = "STAFF",
+                                venueId = addVenueId.trim().ifBlank { null }
+                            )
+                        }
+                        showAddDialog = false
+                        addUserId = ""
+                        addVenueId = ""
+                        loadMembers()
+                    }
+                }) { Text("Добавить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+            }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -1,0 +1,281 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrgManagementScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    // Add member dialog state
+    var showAddDialog by remember { mutableStateOf(false) }
+    var addUserId by remember { mutableStateOf("") }
+    var addRole by remember { mutableStateOf("MANAGER") }
+    var addVenueId by remember { mutableStateOf("") }
+    var roleMenuExpanded by remember { mutableStateOf(false) }
+
+    fun loadMembers() {
+        scope.launch {
+            isLoading = true
+            error = null
+            val token = AppSession.authToken ?: return@launch
+            try {
+                members = AppContainer.orgMemberService.listMembers(token)
+            } catch (e: Exception) {
+                error = e.message
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) { loadMembers() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        // Toolbar
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Управление организацией",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить участника")
+            }
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(members) { member ->
+                    MemberRow(
+                        member = member,
+                        canDelete = true,
+                        onDelete = {
+                            scope.launch {
+                                val token = AppSession.authToken ?: return@launch
+                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                loadMembers()
+                            }
+                        }
+                    )
+                }
+                item { Spacer(Modifier.height(96.dp)) }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("Добавить участника") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = addUserId,
+                        onValueChange = { addUserId = it },
+                        label = { Text("UUID пользователя") },
+                        singleLine = true
+                    )
+                    Box {
+                        OutlinedTextField(
+                            value = addRole,
+                            onValueChange = {},
+                            label = { Text("Роль") },
+                            readOnly = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        TextButton(
+                            onClick = { roleMenuExpanded = true },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text(addRole) }
+                        DropdownMenu(
+                            expanded = roleMenuExpanded,
+                            onDismissRequest = { roleMenuExpanded = false }
+                        ) {
+                            listOf("MANAGER", "STAFF").forEach { role ->
+                                DropdownMenuItem(
+                                    text = { Text(role) },
+                                    onClick = { addRole = role; roleMenuExpanded = false }
+                                )
+                            }
+                        }
+                    }
+                    if (addRole == "STAFF") {
+                        OutlinedTextField(
+                            value = addVenueId,
+                            onValueChange = { addVenueId = it },
+                            label = { Text("UUID площадки") },
+                            singleLine = true
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    scope.launch {
+                        val token = AppSession.authToken ?: return@launch
+                        runCatching {
+                            AppContainer.orgMemberService.addMember(
+                                authToken = token,
+                                userId = addUserId.trim(),
+                                role = addRole,
+                                venueId = addVenueId.trim().ifBlank { null }
+                            )
+                        }
+                        showAddDialog = false
+                        addUserId = ""
+                        addRole = "MANAGER"
+                        addVenueId = ""
+                        loadMembers()
+                    }
+                }) { Text("Добавить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+            }
+        )
+    }
+}
+
+@Composable
+fun MemberRow(
+    member: OrgMemberDto,
+    canDelete: Boolean,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                Icons.Outlined.Person,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = member.role,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                text = member.userId,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1
+            )
+            if (member.venueId != null) {
+                Text(
+                    text = "Площадка: ${member.venueId}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+            }
+        }
+        if (canDelete) {
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Outlined.Delete,
+                    contentDescription = "Удалить",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
@@ -1,0 +1,234 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun VenueAccessScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+    var selectedTab by remember { mutableIntStateOf(0) }
+
+    var incoming by remember { mutableStateOf<List<VenueAccessGrantDto>>(emptyList()) }
+    var outgoing by remember { mutableStateOf<List<VenueAccessGrantDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun load() {
+        scope.launch {
+            isLoading = true
+            error = null
+            val token = AppSession.authToken ?: return@launch
+            try {
+                incoming = AppContainer.venueAccessGrantService.getIncomingRequests(token)
+                outgoing = AppContainer.venueAccessGrantService.getOutgoingRequests(token)
+            } catch (e: Exception) {
+                error = e.message
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) { load() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Аренда площадок",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+            )
+        }
+
+        ScrollableTabRow(selectedTabIndex = selectedTab, edgePadding = 16.dp) {
+            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 },
+                text = { Text("Входящие (${incoming.size})") })
+            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
+                text = { Text("Исходящие (${outgoing.size})") })
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            else -> {
+                val items = if (selectedTab == 0) incoming else outgoing
+                if (items.isEmpty()) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            if (selectedTab == 0) "Входящих запросов нет"
+                            else "Исходящих запросов нет",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp)
+                            .navigationBarsPadding(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        item { Spacer(Modifier.height(8.dp)) }
+                        items(items) { grant ->
+                            GrantCard(
+                                grant = grant,
+                                isIncoming = selectedTab == 0,
+                                onApprove = {
+                                    scope.launch {
+                                        val token = AppSession.authToken ?: return@launch
+                                        runCatching {
+                                            AppContainer.venueAccessGrantService.approve(token, grant.venueId, grant.id)
+                                        }
+                                        load()
+                                    }
+                                },
+                                onReject = {
+                                    scope.launch {
+                                        val token = AppSession.authToken ?: return@launch
+                                        runCatching {
+                                            AppContainer.venueAccessGrantService.reject(token, grant.venueId, grant.id)
+                                        }
+                                        load()
+                                    }
+                                }
+                            )
+                        }
+                        item { Spacer(Modifier.height(96.dp)) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GrantCard(
+    grant: VenueAccessGrantDto,
+    isIncoming: Boolean,
+    onApprove: () -> Unit,
+    onReject: () -> Unit
+) {
+    Column(
+        modifier = androidx.compose.ui.Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = statusLabel(grant.status),
+                style = MaterialTheme.typography.labelMedium,
+                color = statusColor(grant.status)
+            )
+            Text(
+                text = grant.createdAt.take(10),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Text(
+            text = if (isIncoming) "Заявка от орг.: ${grant.requestingOrgId.take(8)}…"
+                   else "Площадка: ${grant.venueId.take(8)}…",
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium)
+        )
+        if (isIncoming && grant.status == "PENDING") {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onApprove, modifier = androidx.compose.ui.Modifier.weight(1f)) {
+                    Text("Одобрить")
+                }
+                OutlinedButton(
+                    onClick = onReject,
+                    modifier = androidx.compose.ui.Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("Отклонить")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun statusLabel(status: String): String = when (status) {
+    "PENDING" -> "Ожидает"
+    "APPROVED" -> "Одобрено"
+    "REJECTED" -> "Отклонено"
+    else -> status
+}
+
+@Composable
+private fun statusColor(status: String) = when (status) {
+    "PENDING" -> MaterialTheme.colorScheme.tertiary
+    "APPROVED" -> MaterialTheme.colorScheme.primary
+    "REJECTED" -> MaterialTheme.colorScheme.error
+    else -> MaterialTheme.colorScheme.onSurfaceVariant
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
@@ -51,6 +51,8 @@ import com.karrad.ticketsclient.ui.navigation.AboutScreen
 import com.karrad.ticketsclient.ui.navigation.EditProfileScreen
 import com.karrad.ticketsclient.ui.navigation.FavoritesScreen
 import com.karrad.ticketsclient.ui.navigation.InterestsScreen
+import com.karrad.ticketsclient.ui.navigation.MemberManagementScreen
+import com.karrad.ticketsclient.ui.navigation.OrgManagementScreen
 import com.karrad.ticketsclient.ui.navigation.SupportScreen
 
 @Composable
@@ -154,6 +156,23 @@ fun ProfileScreen() {
         Spacer(Modifier.height(16.dp))
 
         // ─── Меню ────────────────────────────────────────────────────────────
+        val membership = AppSession.orgMembership
+        if (membership != null) {
+            MenuCard {
+                when (membership.role) {
+                    "OWNER" -> MenuItem(
+                        label = "Управление организацией",
+                        onClick = { rootNavigator.push(OrgManagementScreen) }
+                    )
+                    "MANAGER" -> MenuItem(
+                        label = "Сотрудники",
+                        onClick = { rootNavigator.push(MemberManagementScreen) }
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+
         MenuCard {
             MenuItem(label = "Избранное", onClick = { rootNavigator.push(FavoritesScreen) })
             MenuDivider()

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
@@ -54,6 +54,7 @@ import com.karrad.ticketsclient.ui.navigation.InterestsScreen
 import com.karrad.ticketsclient.ui.navigation.MemberManagementScreen
 import com.karrad.ticketsclient.ui.navigation.OrgManagementScreen
 import com.karrad.ticketsclient.ui.navigation.SupportScreen
+import com.karrad.ticketsclient.ui.navigation.VenueAccessScreen
 
 @Composable
 fun ProfileScreen() {
@@ -160,10 +161,17 @@ fun ProfileScreen() {
         if (membership != null) {
             MenuCard {
                 when (membership.role) {
-                    "OWNER" -> MenuItem(
-                        label = "Управление организацией",
-                        onClick = { rootNavigator.push(OrgManagementScreen) }
-                    )
+                    "OWNER" -> {
+                        MenuItem(
+                            label = "Управление организацией",
+                            onClick = { rootNavigator.push(OrgManagementScreen) }
+                        )
+                        MenuDivider()
+                        MenuItem(
+                            label = "Аренда площадок",
+                            onClick = { rootNavigator.push(VenueAccessScreen) }
+                        )
+                    }
                     "MANAGER" -> MenuItem(
                         label = "Сотрудники",
                         onClick = { rootNavigator.push(MemberManagementScreen) }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -8,6 +8,7 @@ import com.karrad.ticketsclient.data.api.FakeGeoService
 import com.karrad.ticketsclient.data.api.FakeOrderService
 import com.karrad.ticketsclient.data.api.FakeProfileService
 import com.karrad.ticketsclient.data.api.FakeScannerService
+import com.karrad.ticketsclient.data.api.FakeOrgMemberService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
@@ -25,6 +26,7 @@ fun initContainer(baseUrl: String) {
         eventService = FakeEventService(),
         geoService = FakeGeoService(),
         profileService = FakeProfileService(),
-        favoriteService = FakeFavoriteService()
+        favoriteService = FakeFavoriteService(),
+        orgMemberService = FakeOrgMemberService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -10,6 +10,7 @@ import com.karrad.ticketsclient.data.api.FakeProfileService
 import com.karrad.ticketsclient.data.api.FakeScannerService
 import com.karrad.ticketsclient.data.api.FakeOrgMemberService
 import com.karrad.ticketsclient.data.api.FakeTicketService
+import com.karrad.ticketsclient.data.api.FakeVenueAccessGrantService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
 
@@ -27,6 +28,7 @@ fun initContainer(baseUrl: String) {
         geoService = FakeGeoService(),
         profileService = FakeProfileService(),
         favoriteService = FakeFavoriteService(),
-        orgMemberService = FakeOrgMemberService()
+        orgMemberService = FakeOrgMemberService(),
+        venueAccessGrantService = FakeVenueAccessGrantService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
@@ -1,0 +1,61 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+
+class FakeOrgMemberService : OrgMemberService {
+
+    private val members = mutableListOf(
+        OrgMemberDto(
+            id = "member-owner-1",
+            organizationId = "org-1",
+            userId = "user-owner",
+            role = "OWNER"
+        ),
+        OrgMemberDto(
+            id = "member-mgr-1",
+            organizationId = "org-1",
+            userId = "user-mgr",
+            role = "MANAGER"
+        ),
+        OrgMemberDto(
+            id = "member-staff-1",
+            organizationId = "org-1",
+            userId = "user-staff",
+            role = "STAFF",
+            venueId = "venue-1"
+        )
+    )
+
+    override suspend fun getMyMembership(authToken: String): OrgMembershipDto =
+        OrgMembershipDto(
+            memberId = "member-owner-1",
+            organizationId = "org-1",
+            role = "OWNER"
+        )
+
+    override suspend fun listMembers(authToken: String): List<OrgMemberDto> = members.toList()
+
+    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto {
+        val member = OrgMemberDto(
+            id = "member-new-${members.size}",
+            organizationId = "org-1",
+            userId = userId,
+            role = role,
+            venueId = venueId
+        )
+        members.add(member)
+        return member
+    }
+
+    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto {
+        val index = members.indexOfFirst { it.id == memberId }
+        val updated = members[index].copy(role = role, venueId = venueId)
+        members[index] = updated
+        return updated
+    }
+
+    override suspend fun deleteMember(authToken: String, memberId: String) {
+        members.removeAll { it.id == memberId }
+    }
+}

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueAccessGrantService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueAccessGrantService.kt
@@ -1,0 +1,56 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
+
+class FakeVenueAccessGrantService : VenueAccessGrantService {
+
+    private val incoming = mutableListOf(
+        VenueAccessGrantDto(
+            id = "grant-1",
+            venueId = "venue-1",
+            requestingOrgId = "org-2",
+            status = "PENDING",
+            createdAt = "2026-04-24T10:00:00Z"
+        )
+    )
+
+    private val outgoing = mutableListOf(
+        VenueAccessGrantDto(
+            id = "grant-2",
+            venueId = "venue-ext-1",
+            requestingOrgId = "org-1",
+            status = "PENDING",
+            createdAt = "2026-04-23T09:00:00Z"
+        )
+    )
+
+    override suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto> = incoming.toList()
+
+    override suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto> = outgoing.toList()
+
+    override suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto {
+        val grant = VenueAccessGrantDto(
+            id = "grant-new-${outgoing.size}",
+            venueId = venueId,
+            requestingOrgId = requestingOrgId,
+            status = "PENDING",
+            createdAt = "2026-04-25T10:00:00Z"
+        )
+        outgoing.add(grant)
+        return grant
+    }
+
+    override suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto {
+        val index = incoming.indexOfFirst { it.id == grantId }
+        val updated = incoming[index].copy(status = "APPROVED")
+        incoming[index] = updated
+        return updated
+    }
+
+    override suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto {
+        val index = incoming.indexOfFirst { it.id == grantId }
+        val updated = incoming[index].copy(status = "REJECTED")
+        incoming[index] = updated
+        return updated
+    }
+}


### PR DESCRIPTION
## Summary

- `VenueAccessGrantDto`, `VenueAccessGrantService`, `VenueAccessGrantApiService` — слой данных для заявок на аренду площадок
- `FakeVenueAccessGrantService` — тестовые данные для mock-флейвора (1 входящая PENDING, 1 исходящая PENDING)
- `VenueAccessScreen` — двухвкладочный экран «Входящие» / «Исходящие» с одобрением/отклонением PENDING-заявок (только OWNER)
- `AppContainer` — добавлен `venueAccessGrantService`
- `ProfileScreen` — пункт «Аренда площадок» для роли OWNER (рядом с «Управление организацией»)
- `AppScreen` — навигационный объект `VenueAccessScreen`

Closes #124

## Test plan

- [ ] Войти как пользователь с ролью OWNER — в профиле виден пункт «Аренда площадок»
- [ ] Открыть экран — отображаются вкладки «Входящие» и «Исходящие»
- [ ] Во вкладке «Входящие» отображается карточка со статусом «Ожидает» и кнопками «Одобрить» / «Отклонить»
- [ ] После нажатия «Одобрить» / «Отклонить» список перезагружается, статус меняется
- [ ] Вкладка «Исходящие» отображает исходящие заявки без кнопок действий
- [ ] Пользователи MANAGER/STAFF не видят пункт «Аренда площадок»

🤖 Generated with [Claude Code](https://claude.com/claude-code)