### PR TITLE
feat(#129): Ktor auth interceptor

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
@@ -1,15 +1,29 @@
 package com.karrad.ticketsclient.data.api
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.plugin
+import io.ktor.client.request.header
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-fun createHttpClient(): HttpClient = HttpClient {
-    install(ContentNegotiation) {
-        json(Json {
-            ignoreUnknownKeys = true
-            coerceInputValues = true
-        })
+fun createHttpClient(tokenProvider: () -> String? = { null }): HttpClient {
+    val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                coerceInputValues = true
+            })
+        }
     }
+    client.plugin(HttpSend).intercept { request ->
+        if (request.headers["Authorization"] == null) {
+            tokenProvider()?.let { token ->
+                request.header("Authorization", "Bearer $token")
+            }
+        }
+        execute(request)
+    }
+    return client
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryApiService.kt
@@ -4,7 +4,6 @@ import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 
 class DiscoveryApiService(
@@ -13,17 +12,14 @@ class DiscoveryApiService(
 ) : DiscoveryService {
     override suspend fun getDiscoveryFeed(
         city: String,
-        authToken: String?,
         page: Int,
         size: Int,
         date: String?
-    ): DiscoveryFeedResponseDto {
-        return httpClient.get("$baseUrl/api/v1/discovery") {
+    ): DiscoveryFeedResponseDto =
+        httpClient.get("$baseUrl/api/v1/discovery") {
             parameter("city", city)
             parameter("page", page)
             parameter("size", size)
             date?.let { parameter("date", it) }
-            authToken?.let { header("Authorization", "Bearer $it") }
         }.body()
-    }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/DiscoveryService.kt
@@ -5,7 +5,6 @@ import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
 interface DiscoveryService {
     suspend fun getDiscoveryFeed(
         city: String,
-        authToken: String? = null,
         page: Int = 0,
         size: Int = 20,
         date: String? = null

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteApiService.kt
@@ -3,7 +3,6 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -20,22 +19,17 @@ class FavoriteApiService(
     private val baseUrl: String
 ) : FavoriteService {
 
-    override suspend fun add(eventId: String, token: String) {
+    override suspend fun add(eventId: String) {
         httpClient.post("$baseUrl/api/v1/favorites") {
-            bearerAuth(token)
             contentType(ContentType.Application.Json)
             setBody(AddFavoriteRequest(eventId))
         }
     }
 
-    override suspend fun remove(eventId: String, token: String) {
-        httpClient.delete("$baseUrl/api/v1/favorites/$eventId") {
-            bearerAuth(token)
-        }
+    override suspend fun remove(eventId: String) {
+        httpClient.delete("$baseUrl/api/v1/favorites/$eventId")
     }
 
-    override suspend fun list(token: String): List<EventDto> =
-        httpClient.get("$baseUrl/api/v1/favorites") {
-            bearerAuth(token)
-        }.body()
+    override suspend fun list(): List<EventDto> =
+        httpClient.get("$baseUrl/api/v1/favorites").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FavoriteService.kt
@@ -3,7 +3,7 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.EventDto
 
 interface FavoriteService {
-    suspend fun add(eventId: String, token: String)
-    suspend fun remove(eventId: String, token: String)
-    suspend fun list(token: String): List<EventDto>
+    suspend fun add(eventId: String)
+    suspend fun remove(eventId: String)
+    suspend fun list(): List<EventDto>
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderApiService.kt
@@ -4,7 +4,6 @@ import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -16,20 +15,15 @@ class OrderApiService(
     private val baseUrl: String
 ) : OrderService {
 
-    override suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto =
+    override suspend fun createOrder(eventId: String, request: CreateOrderRequestDto): OrderDto =
         httpClient.post("$baseUrl/api/v1/events/$eventId/orders") {
-            bearerAuth(authToken)
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()
 
-    override suspend fun confirmPayment(orderId: String, authToken: String): OrderDto =
-        httpClient.post("$baseUrl/api/v1/orders/$orderId/confirm-payment") {
-            bearerAuth(authToken)
-        }.body()
+    override suspend fun confirmPayment(orderId: String): OrderDto =
+        httpClient.post("$baseUrl/api/v1/orders/$orderId/confirm-payment").body()
 
-    override suspend fun getOrder(orderId: String, authToken: String): OrderDto =
-        httpClient.get("$baseUrl/api/v1/orders/$orderId") {
-            bearerAuth(authToken)
-        }.body()
+    override suspend fun getOrder(orderId: String): OrderDto =
+        httpClient.get("$baseUrl/api/v1/orders/$orderId").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrderService.kt
@@ -4,7 +4,7 @@ import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 
 interface OrderService {
-    suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto
-    suspend fun confirmPayment(orderId: String, authToken: String): OrderDto
-    suspend fun getOrder(orderId: String, authToken: String): OrderDto
+    suspend fun createOrder(eventId: String, request: CreateOrderRequestDto): OrderDto
+    suspend fun confirmPayment(orderId: String): OrderDto
+    suspend fun getOrder(orderId: String): OrderDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
@@ -8,7 +8,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -21,36 +20,27 @@ class OrgMemberApiService(
     private val baseUrl: String
 ) : OrgMemberService {
 
-    override suspend fun getMyMembership(authToken: String): OrgMembershipDto? {
-        val response = httpClient.get("$baseUrl/api/v1/my/organization/membership") {
-            header("Authorization", "Bearer $authToken")
-        }
-        return if (response.status == HttpStatusCode.NotFound) null
-        else response.body()
+    override suspend fun getMyMembership(): OrgMembershipDto? {
+        val response = httpClient.get("$baseUrl/api/v1/my/organization/membership")
+        return if (response.status == HttpStatusCode.NotFound) null else response.body()
     }
 
-    override suspend fun listMembers(authToken: String): List<OrgMemberDto> =
-        httpClient.get("$baseUrl/api/v1/my/organization/members") {
-            header("Authorization", "Bearer $authToken")
-        }.body()
+    override suspend fun listMembers(): List<OrgMemberDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/members").body()
 
-    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto =
+    override suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto =
         httpClient.post("$baseUrl/api/v1/my/organization/members") {
-            header("Authorization", "Bearer $authToken")
             contentType(ContentType.Application.Json)
             setBody(AddMemberRequest(userId = userId, role = role, venueId = venueId))
         }.body()
 
-    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto =
+    override suspend fun updateMember(memberId: String, role: String, venueId: String?): OrgMemberDto =
         httpClient.put("$baseUrl/api/v1/my/organization/members/$memberId") {
-            header("Authorization", "Bearer $authToken")
             contentType(ContentType.Application.Json)
             setBody(UpdateMemberRequest(role = role, venueId = venueId))
         }.body()
 
-    override suspend fun deleteMember(authToken: String, memberId: String) {
-        httpClient.delete("$baseUrl/api/v1/my/organization/members/$memberId") {
-            header("Authorization", "Bearer $authToken")
-        }
+    override suspend fun deleteMember(memberId: String) {
+        httpClient.delete("$baseUrl/api/v1/my/organization/members/$memberId")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
@@ -5,17 +5,17 @@ import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 
 interface OrgMemberService {
     /** Возвращает членство текущего пользователя в организации, или null если не состоит. */
-    suspend fun getMyMembership(authToken: String): OrgMembershipDto?
+    suspend fun getMyMembership(): OrgMembershipDto?
 
     /** Список членов организации (требует OWNER или MANAGER). */
-    suspend fun listMembers(authToken: String): List<OrgMemberDto>
+    suspend fun listMembers(): List<OrgMemberDto>
 
     /** Добавить участника (OWNER — любую роль; MANAGER — только STAFF). */
-    suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto
+    suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto
 
     /** Обновить роль/venue участника (только OWNER). */
-    suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto
+    suspend fun updateMember(memberId: String, role: String, venueId: String?): OrgMemberDto
 
     /** Удалить участника (OWNER — любого; MANAGER — только STAFF). */
-    suspend fun deleteMember(authToken: String, memberId: String)
+    suspend fun deleteMember(memberId: String)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileApiService.kt
@@ -5,7 +5,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
-import io.ktor.client.request.header
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -26,27 +25,19 @@ class ProfileApiService(
     private val baseUrl: String
 ) : ProfileService {
 
-    override suspend fun updateProfile(
-        authToken: String,
-        fullName: String?,
-        interests: List<String>?
-    ): UserDto = httpClient.patch("$baseUrl/auth/me") {
-        header("Authorization", "Bearer $authToken")
-        contentType(ContentType.Application.Json)
-        setBody(UpdateProfileRequest(fullName, interests))
-    }.body()
+    override suspend fun updateProfile(fullName: String?, interests: List<String>?): UserDto =
+        httpClient.patch("$baseUrl/auth/me") {
+            contentType(ContentType.Application.Json)
+            setBody(UpdateProfileRequest(fullName, interests))
+        }.body()
 
-    override suspend fun uploadAvatar(
-        authToken: String,
-        imageBytes: ByteArray,
-        extension: String
-    ): UserDto = httpClient.post("$baseUrl/auth/me/avatar") {
-        header("Authorization", "Bearer $authToken")
-        setBody(MultiPartFormDataContent(formData {
-            append("file", imageBytes, Headers.build {
-                append(HttpHeaders.ContentDisposition, "filename=\"avatar.$extension\"")
-                append(HttpHeaders.ContentType, "image/$extension")
-            })
-        }))
-    }.body()
+    override suspend fun uploadAvatar(imageBytes: ByteArray, extension: String): UserDto =
+        httpClient.post("$baseUrl/auth/me/avatar") {
+            setBody(MultiPartFormDataContent(formData {
+                append("file", imageBytes, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"avatar.$extension\"")
+                    append(HttpHeaders.ContentType, "image/$extension")
+                })
+            }))
+        }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ProfileService.kt
@@ -3,6 +3,6 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.UserDto
 
 interface ProfileService {
-    suspend fun updateProfile(authToken: String, fullName: String?, interests: List<String>?): UserDto
-    suspend fun uploadAvatar(authToken: String, imageBytes: ByteArray, extension: String): UserDto
+    suspend fun updateProfile(fullName: String?, interests: List<String>?): UserDto
+    suspend fun uploadAvatar(imageBytes: ByteArray, extension: String): UserDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerApiService.kt
@@ -5,7 +5,6 @@ import com.karrad.ticketsclient.data.api.dto.TicketValidationResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 
 class ScannerApiService(
@@ -13,17 +12,9 @@ class ScannerApiService(
     private val baseUrl: String
 ) : ScannerService {
 
-    override suspend fun getMyOrgEvents(authToken: String?): List<OrgEventItem> =
-        httpClient.get("$baseUrl/api/v1/my/organization/events") {
-            authToken?.let { header("Authorization", "Bearer $it") }
-        }.body()
+    override suspend fun getMyOrgEvents(): List<OrgEventItem> =
+        httpClient.get("$baseUrl/api/v1/my/organization/events").body()
 
-    override suspend fun validateTicket(
-        eventId: String,
-        ticketId: String,
-        authToken: String?
-    ): TicketValidationResponse =
-        httpClient.post("$baseUrl/api/v1/events/$eventId/tickets/$ticketId/validate") {
-            authToken?.let { header("Authorization", "Bearer $it") }
-        }.body()
+    override suspend fun validateTicket(eventId: String, ticketId: String): TicketValidationResponse =
+        httpClient.post("$baseUrl/api/v1/events/$eventId/tickets/$ticketId/validate").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ScannerService.kt
@@ -4,6 +4,6 @@ import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.TicketValidationResponse
 
 interface ScannerService {
-    suspend fun getMyOrgEvents(authToken: String?): List<OrgEventItem>
-    suspend fun validateTicket(eventId: String, ticketId: String, authToken: String?): TicketValidationResponse
+    suspend fun getMyOrgEvents(): List<OrgEventItem>
+    suspend fun validateTicket(eventId: String, ticketId: String): TicketValidationResponse
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketApiService.kt
@@ -3,7 +3,6 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.TicketDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 
 class TicketApiService(
@@ -11,8 +10,6 @@ class TicketApiService(
     private val baseUrl: String
 ) : TicketService {
 
-    override suspend fun getMyTickets(authToken: String): List<TicketDto> =
-        httpClient.get("$baseUrl/api/v1/tickets/me") {
-            bearerAuth(authToken)
-        }.body()
+    override suspend fun getMyTickets(): List<TicketDto> =
+        httpClient.get("$baseUrl/api/v1/tickets/me").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/TicketService.kt
@@ -3,5 +3,5 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.TicketDto
 
 interface TicketService {
-    suspend fun getMyTickets(authToken: String): List<TicketDto>
+    suspend fun getMyTickets(): List<TicketDto>
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantApiService.kt
@@ -5,7 +5,6 @@ import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -16,30 +15,21 @@ class VenueAccessGrantApiService(
     private val baseUrl: String
 ) : VenueAccessGrantService {
 
-    override suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto> =
-        httpClient.get("$baseUrl/api/v1/my/organization/incoming-access-requests") {
-            header("Authorization", "Bearer $authToken")
-        }.body()
+    override suspend fun getIncomingRequests(): List<VenueAccessGrantDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/incoming-access-requests").body()
 
-    override suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto> =
-        httpClient.get("$baseUrl/api/v1/my/organization/outgoing-access-requests") {
-            header("Authorization", "Bearer $authToken")
-        }.body()
+    override suspend fun getOutgoingRequests(): List<VenueAccessGrantDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/outgoing-access-requests").body()
 
-    override suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto =
+    override suspend fun requestAccess(venueId: String, requestingOrgId: String): VenueAccessGrantDto =
         httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests") {
-            header("Authorization", "Bearer $authToken")
             contentType(ContentType.Application.Json)
             setBody(RequestVenueAccessRequest(requestingOrgId = requestingOrgId))
         }.body()
 
-    override suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto =
-        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/approve") {
-            header("Authorization", "Bearer $authToken")
-        }.body()
+    override suspend fun approve(venueId: String, grantId: String): VenueAccessGrantDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/approve").body()
 
-    override suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto =
-        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/reject") {
-            header("Authorization", "Bearer $authToken")
-        }.body()
+    override suspend fun reject(venueId: String, grantId: String): VenueAccessGrantDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/access-requests/$grantId/reject").body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueAccessGrantService.kt
@@ -4,17 +4,17 @@ import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 
 interface VenueAccessGrantService {
     /** Входящие запросы на аренду площадок организации (для OWNER). */
-    suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto>
+    suspend fun getIncomingRequests(): List<VenueAccessGrantDto>
 
     /** Исходящие запросы на аренду чужих площадок (для OWNER/MANAGER). */
-    suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto>
+    suspend fun getOutgoingRequests(): List<VenueAccessGrantDto>
 
     /** Отправить запрос на аренду площадки. */
-    suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto
+    suspend fun requestAccess(venueId: String, requestingOrgId: String): VenueAccessGrantDto
 
     /** Одобрить входящий запрос. */
-    suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto
+    suspend fun approve(venueId: String, grantId: String): VenueAccessGrantDto
 
     /** Отклонить входящий запрос. */
-    suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto
+    suspend fun reject(venueId: String, grantId: String): VenueAccessGrantDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -22,6 +22,7 @@ import com.karrad.ticketsclient.data.api.TicketApiService
 import com.karrad.ticketsclient.data.api.TicketService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantApiService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantService
+import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.createHttpClient
 
 /**
@@ -101,7 +102,7 @@ object AppContainer {
 }
 
 fun AppContainer.initReal(baseUrl: String) {
-    val client = createHttpClient()
+    val client = createHttpClient { AppSession.authToken }
     init(
         isMock = false,
         httpClient = client,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -547,17 +547,14 @@ private fun EventCard(
                         val newFav = !isFav
                         isFav = newFav
                         AppSession.toggleFavorite(event.id, newFav)
-                        val token = AppSession.authToken
-                        if (token != null) {
-                            scope.launch {
-                                runCatching {
-                                    if (newFav) AppContainer.favoriteService.add(event.id, token)
-                                    else AppContainer.favoriteService.remove(event.id, token)
-                                }.onFailure {
-                                    // rollback on error
-                                    isFav = !newFav
-                                    AppSession.toggleFavorite(event.id, !newFav)
-                                }
+                        scope.launch {
+                            runCatching {
+                                if (newFav) AppContainer.favoriteService.add(event.id)
+                                else AppContainer.favoriteService.remove(event.id)
+                            }.onFailure {
+                                // rollback on error
+                                isFav = !newFav
+                                AppSession.toggleFavorite(event.id, !newFav)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModel.kt
@@ -30,7 +30,6 @@ sealed interface FeedState {
 
 class FeedViewModel(
     private val discoveryService: DiscoveryService,
-    private val getAuthToken: () -> String? = { AppSession.authToken },
     private val onCacheUpdated: (List<EventDto>) -> Unit = { AppSession.cachedEvents = it },
     private val onOfflineChanged: (Boolean) -> Unit = { AppSession.isOffline = it }
 ) : ViewModel() {
@@ -83,7 +82,6 @@ class FeedViewModel(
                 currentPage++
                 val next = discoveryService.getDiscoveryFeed(
                     city = AppSession.city,
-                    authToken = getAuthToken(),
                     page = currentPage,
                     date = currentDate
                 )
@@ -92,7 +90,7 @@ class FeedViewModel(
                 onCacheUpdated((merged.forYou + merged.byCategory.flatMap { it.events }).distinctBy { it.id })
                 _state.value = FeedState.Success(merged, hasMore = next.forYou.isNotEmpty())
             } catch (_: Exception) {
-                // Keep current state, loadMore failed silently
+                // loadMore fails silently — keep current state
             } finally {
                 isLoadingMore = false
             }
@@ -107,7 +105,6 @@ class FeedViewModel(
             try {
                 val feed = discoveryService.getDiscoveryFeed(
                     city = AppSession.city,
-                    authToken = getAuthToken(),
                     page = 0,
                     date = currentDate
                 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
@@ -60,9 +60,8 @@ fun MainScreen() {
     LaunchedEffect(Unit) {
         AppSession.userId?.let { CrashReporter.setUserId(it) }
         if (!AppContainer.isMock) {
-            val token = AppSession.authToken ?: return@LaunchedEffect
             val membership = try {
-                AppContainer.orgMemberService.getMyMembership(token)
+                AppContainer.orgMemberService.getMyMembership()
             } catch (e: Exception) {
                 println("MainScreen: не удалось получить членство — ${e.message}")
                 null

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
@@ -61,7 +61,7 @@ fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
 
     LaunchedEffect(orderId) {
         try {
-            orderStatus = AppContainer.orderService.getOrder(orderId, AppSession.authToken ?: "").status
+            orderStatus = AppContainer.orderService.getOrder(orderId).status
         } catch (_: Exception) { }
     }
 
@@ -174,7 +174,7 @@ fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
                     error = null
                     scope.launch {
                         try {
-                            AppContainer.orderService.confirmPayment(orderId, AppSession.authToken ?: "")
+                            AppContainer.orderService.confirmPayment(orderId)
                             success = true
                         } catch (e: Exception) {
                             error = "Ошибка оплаты. Попробуйте ещё раз."

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -61,10 +60,9 @@ fun MemberManagementScreen() {
         scope.launch {
             isLoading = true
             error = null
-            val token = AppSession.authToken ?: return@launch
             try {
                 // MANAGER видит только STAFF
-                members = AppContainer.orgMemberService.listMembers(token)
+                members = AppContainer.orgMemberService.listMembers()
                     .filter { it.role == "STAFF" }
             } catch (e: Exception) {
                 error = e.message
@@ -128,8 +126,7 @@ fun MemberManagementScreen() {
                         canDelete = true,
                         onDelete = {
                             scope.launch {
-                                val token = AppSession.authToken ?: return@launch
-                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
                                 loadMembers()
                             }
                         }
@@ -163,10 +160,8 @@ fun MemberManagementScreen() {
             confirmButton = {
                 Button(onClick = {
                     scope.launch {
-                        val token = AppSession.authToken ?: return@launch
                         runCatching {
                             AppContainer.orgMemberService.addMember(
-                                authToken = token,
                                 userId = addUserId.trim(),
                                 role = "STAFF",
                                 venueId = addVenueId.trim().ifBlank { null }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -74,9 +73,8 @@ fun OrgManagementScreen() {
         scope.launch {
             isLoading = true
             error = null
-            val token = AppSession.authToken ?: return@launch
             try {
-                members = AppContainer.orgMemberService.listMembers(token)
+                members = AppContainer.orgMemberService.listMembers()
             } catch (e: Exception) {
                 error = e.message
             } finally {
@@ -134,8 +132,7 @@ fun OrgManagementScreen() {
                         canDelete = true,
                         onDelete = {
                             scope.launch {
-                                val token = AppSession.authToken ?: return@launch
-                                runCatching { AppContainer.orgMemberService.deleteMember(token, member.id) }
+                                runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
                                 loadMembers()
                             }
                         }
@@ -195,10 +192,8 @@ fun OrgManagementScreen() {
             confirmButton = {
                 Button(onClick = {
                     scope.launch {
-                        val token = AppSession.authToken ?: return@launch
                         runCatching {
                             AppContainer.orgMemberService.addMember(
-                                authToken = token,
                                 userId = addUserId.trim(),
                                 role = addRole,
                                 venueId = addVenueId.trim().ifBlank { null }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -62,10 +61,9 @@ fun VenueAccessScreen() {
         scope.launch {
             isLoading = true
             error = null
-            val token = AppSession.authToken ?: return@launch
             try {
-                incoming = AppContainer.venueAccessGrantService.getIncomingRequests(token)
-                outgoing = AppContainer.venueAccessGrantService.getOutgoingRequests(token)
+                incoming = AppContainer.venueAccessGrantService.getIncomingRequests()
+                outgoing = AppContainer.venueAccessGrantService.getOutgoingRequests()
             } catch (e: Exception) {
                 error = e.message
             } finally {
@@ -136,18 +134,16 @@ fun VenueAccessScreen() {
                                 isIncoming = selectedTab == 0,
                                 onApprove = {
                                     scope.launch {
-                                        val token = AppSession.authToken ?: return@launch
                                         runCatching {
-                                            AppContainer.venueAccessGrantService.approve(token, grant.venueId, grant.id)
+                                            AppContainer.venueAccessGrantService.approve(grant.venueId, grant.id)
                                         }
                                         load()
                                     }
                                 },
                                 onReject = {
                                     scope.launch {
-                                        val token = AppSession.authToken ?: return@launch
                                         runCatching {
-                                            AppContainer.venueAccessGrantService.reject(token, grant.venueId, grant.id)
+                                            AppContainer.venueAccessGrantService.reject(grant.venueId, grant.id)
                                         }
                                         load()
                                     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -181,20 +181,13 @@ fun EditProfileScreen() {
                     saveError = null
                     scope.launch {
                         try {
-                            val token = AppSession.authToken
-                            if (token != null) {
-                                val updated = AppContainer.profileService.updateProfile(
-                                    authToken = token,
-                                    fullName = name.trim().ifBlank { null },
-                                    interests = selectedInterests.toList()
-                                )
-                                AppSession.userName = updated.fullName
-                                AppSession.userInterests = updated.interests
-                                AppSession.userAvatarUrl = updated.avatarUrl
-                            } else {
-                                AppSession.userName = name.trim().ifBlank { AppSession.userName }
-                                AppSession.userInterests = selectedInterests.toList()
-                            }
+                            val updated = AppContainer.profileService.updateProfile(
+                                fullName = name.trim().ifBlank { null },
+                                interests = selectedInterests.toList()
+                            )
+                            AppSession.userName = updated.fullName
+                            AppSession.userInterests = updated.interests
+                            AppSession.userAvatarUrl = updated.avatarUrl
                             AppSession.city = city.trim().ifBlank { AppSession.city }
                             navigator.pop()
                         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -55,16 +55,14 @@ fun FavoritesScreen() {
     var loading by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
-        val token = AppSession.authToken
-        if (token != null) {
-            runCatching { AppContainer.favoriteService.list(token) }
-                .onSuccess { list ->
-                    favorites = list
-                    AppSession.setFavorites(list.map { it.id })
-                }
-        } else {
-            favorites = AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) }
-        }
+        runCatching { AppContainer.favoriteService.list() }
+            .onSuccess { list ->
+                favorites = list
+                AppSession.setFavorites(list.map { it.id })
+            }
+            .onFailure {
+                favorites = AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) }
+            }
         loading = false
     }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
@@ -75,7 +75,7 @@ fun ScannerScreen() {
 
     LaunchedEffect(Unit) {
         try {
-            val events = AppContainer.scannerService.getMyOrgEvents(AppSession.authToken)
+            val events = AppContainer.scannerService.getMyOrgEvents()
             state = if (events.isEmpty()) ScannerState.NoAccess else ScannerState.EventList(events)
         } catch (e: Exception) {
             state = ScannerState.NoAccess
@@ -94,7 +94,7 @@ fun ScannerScreen() {
             onBack = {
                 scope.launch {
                     try {
-                        val events = AppContainer.scannerService.getMyOrgEvents(AppSession.authToken)
+                        val events = AppContainer.scannerService.getMyOrgEvents()
                         state = if (events.isEmpty()) ScannerState.NoAccess else ScannerState.EventList(events)
                     } catch (e: Exception) {
                         state = ScannerState.NoAccess
@@ -108,8 +108,7 @@ fun ScannerScreen() {
                         try {
                             val result = AppContainer.scannerService.validateTicket(
                                 eventId = s.event.id,
-                                ticketId = ticketId,
-                                authToken = AppSession.authToken
+                                ticketId = ticketId
                             )
                             state = s.copy(validating = false, result = result)
                         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
@@ -314,7 +314,6 @@ fun SeatMapScreen(eventId: String) {
                                     try {
                                         val order = AppContainer.orderService.createOrder(
                                             eventId = eventId,
-                                            authToken = AppSession.authToken ?: "",
                                             request = CreateOrderRequestDto(
                                                 seatKeys = selectedSeats.map { seat ->
                                                     SeatKeyRequestDto(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
@@ -64,7 +64,7 @@ fun TicketsScreen() {
 
     LaunchedEffect(Unit) {
         try {
-            val loaded = AppContainer.ticketService.getMyTickets(AppSession.authToken ?: "")
+            val loaded = AppContainer.ticketService.getMyTickets()
             tickets = loaded
             AppSession.cachedTickets = loaded   // обновляем кеш при успехе
             AppSession.isOffline = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
@@ -266,7 +266,6 @@ fun TicketTypeScreen(eventId: String) {
                                 try {
                                     val order = AppContainer.orderService.createOrder(
                                         eventId = eventId,
-                                        authToken = AppSession.authToken ?: "",
                                         request = CreateOrderRequestDto(
                                             admissionItems = quantities
                                                 .filterValues { it > 0 }

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedViewModelTest.kt
@@ -105,7 +105,6 @@ private class FakeDiscoveryService(
 ) : DiscoveryService {
     override suspend fun getDiscoveryFeed(
         city: String,
-        authToken: String?,
         page: Int,
         size: Int,
         date: String?
@@ -115,7 +114,6 @@ private class FakeDiscoveryService(
 private class ThrowingDiscoveryService : DiscoveryService {
     override suspend fun getDiscoveryFeed(
         city: String,
-        authToken: String?,
         page: Int,
         size: Int,
         date: String?

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeDiscoveryApiService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeDiscoveryApiService.kt
@@ -9,13 +9,10 @@ class FakeDiscoveryApiService : DiscoveryService {
 
     override suspend fun getDiscoveryFeed(
         city: String,
-        authToken: String?,
         page: Int,
         size: Int,
         date: String?
-    ): DiscoveryFeedResponseDto {
-        return FEED
-    }
+    ): DiscoveryFeedResponseDto = FEED
 
     companion object {
         private val catTheatre  = CategoryDto("cat-theatre",  "theatre",  "Театры")

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeFavoriteService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeFavoriteService.kt
@@ -5,15 +5,15 @@ import com.karrad.ticketsclient.data.api.dto.EventDto
 class FakeFavoriteService : FavoriteService {
     private val added = mutableSetOf<String>()
 
-    override suspend fun add(eventId: String, token: String) {
+    override suspend fun add(eventId: String) {
         added.add(eventId)
     }
 
-    override suspend fun remove(eventId: String, token: String) {
+    override suspend fun remove(eventId: String) {
         added.remove(eventId)
     }
 
-    override suspend fun list(token: String): List<EventDto> {
+    override suspend fun list(): List<EventDto> {
         if (added.isEmpty()) return emptyList()
         val feed = FakeDiscoveryApiService.FEED
         val allEvents = (feed.forYou + feed.tomorrow + feed.dayAfterTomorrow +

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrderService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrderService.kt
@@ -4,13 +4,9 @@ import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.OrderDto
 import kotlinx.coroutines.delay
 
-/**
- * Мок-реализация для разработки без бекенда.
- * Имитирует успешный заказ с небольшой задержкой.
- */
 class FakeOrderService : OrderService {
 
-    override suspend fun createOrder(eventId: String, authToken: String, request: CreateOrderRequestDto): OrderDto {
+    override suspend fun createOrder(eventId: String, request: CreateOrderRequestDto): OrderDto {
         delay(800)
         val totalPrice = when {
             request.seatKeys != null -> request.seatKeys.size * 1500
@@ -26,7 +22,7 @@ class FakeOrderService : OrderService {
         )
     }
 
-    override suspend fun confirmPayment(orderId: String, authToken: String): OrderDto {
+    override suspend fun confirmPayment(orderId: String): OrderDto {
         delay(1000)
         return OrderDto(
             id = orderId,
@@ -38,13 +34,11 @@ class FakeOrderService : OrderService {
         )
     }
 
-    override suspend fun getOrder(orderId: String, authToken: String): OrderDto {
-        return OrderDto(
-            id = orderId,
-            eventId = "e-fake",
-            status = "PAID",
-            totalPrice = 1500,
-            amount = 1500
-        )
-    }
+    override suspend fun getOrder(orderId: String): OrderDto = OrderDto(
+        id = orderId,
+        eventId = "e-fake",
+        status = "PAID",
+        totalPrice = 1500,
+        amount = 1500
+    )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
@@ -6,37 +6,17 @@ import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 class FakeOrgMemberService : OrgMemberService {
 
     private val members = mutableListOf(
-        OrgMemberDto(
-            id = "member-owner-1",
-            organizationId = "org-1",
-            userId = "user-owner",
-            role = "OWNER"
-        ),
-        OrgMemberDto(
-            id = "member-mgr-1",
-            organizationId = "org-1",
-            userId = "user-mgr",
-            role = "MANAGER"
-        ),
-        OrgMemberDto(
-            id = "member-staff-1",
-            organizationId = "org-1",
-            userId = "user-staff",
-            role = "STAFF",
-            venueId = "venue-1"
-        )
+        OrgMemberDto(id = "member-owner-1", organizationId = "org-1", userId = "user-owner", role = "OWNER"),
+        OrgMemberDto(id = "member-mgr-1", organizationId = "org-1", userId = "user-mgr", role = "MANAGER"),
+        OrgMemberDto(id = "member-staff-1", organizationId = "org-1", userId = "user-staff", role = "STAFF", venueId = "venue-1")
     )
 
-    override suspend fun getMyMembership(authToken: String): OrgMembershipDto =
-        OrgMembershipDto(
-            memberId = "member-owner-1",
-            organizationId = "org-1",
-            role = "OWNER"
-        )
+    override suspend fun getMyMembership(): OrgMembershipDto =
+        OrgMembershipDto(memberId = "member-owner-1", organizationId = "org-1", role = "OWNER")
 
-    override suspend fun listMembers(authToken: String): List<OrgMemberDto> = members.toList()
+    override suspend fun listMembers(): List<OrgMemberDto> = members.toList()
 
-    override suspend fun addMember(authToken: String, userId: String, role: String, venueId: String?): OrgMemberDto {
+    override suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto {
         val member = OrgMemberDto(
             id = "member-new-${members.size}",
             organizationId = "org-1",
@@ -48,14 +28,14 @@ class FakeOrgMemberService : OrgMemberService {
         return member
     }
 
-    override suspend fun updateMember(authToken: String, memberId: String, role: String, venueId: String?): OrgMemberDto {
+    override suspend fun updateMember(memberId: String, role: String, venueId: String?): OrgMemberDto {
         val index = members.indexOfFirst { it.id == memberId }
         val updated = members[index].copy(role = role, venueId = venueId)
         members[index] = updated
         return updated
     }
 
-    override suspend fun deleteMember(authToken: String, memberId: String) {
+    override suspend fun deleteMember(memberId: String) {
         members.removeAll { it.id == memberId }
     }
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeProfileService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeProfileService.kt
@@ -5,11 +5,7 @@ import com.karrad.ticketsclient.data.api.dto.UserDto
 
 class FakeProfileService : ProfileService {
 
-    override suspend fun updateProfile(
-        authToken: String,
-        fullName: String?,
-        interests: List<String>?
-    ): UserDto = UserDto(
+    override suspend fun updateProfile(fullName: String?, interests: List<String>?): UserDto = UserDto(
         id = AppSession.userId ?: "fake-user",
         fullName = fullName ?: AppSession.userName,
         phone = AppSession.userPhone,
@@ -18,11 +14,7 @@ class FakeProfileService : ProfileService {
         interests = interests ?: AppSession.userInterests
     )
 
-    override suspend fun uploadAvatar(
-        authToken: String,
-        imageBytes: ByteArray,
-        extension: String
-    ): UserDto = UserDto(
+    override suspend fun uploadAvatar(imageBytes: ByteArray, extension: String): UserDto = UserDto(
         id = AppSession.userId ?: "fake-user",
         fullName = AppSession.userName,
         phone = AppSession.userPhone,

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeScannerService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeScannerService.kt
@@ -10,34 +10,18 @@ class FakeScannerService : ScannerService {
         OrgEventItem("evt-021", "Вечеринка 90-х", "2026-04-03T18:00:00Z")
     )
 
-    override suspend fun getMyOrgEvents(authToken: String?): List<OrgEventItem> = orgEvents
+    override suspend fun getMyOrgEvents(): List<OrgEventItem> = orgEvents
 
-    override suspend fun validateTicket(
-        eventId: String,
-        ticketId: String,
-        authToken: String?
-    ): TicketValidationResponse = when (ticketId.trim().lowercase()) {
-        "t-001" -> TicketValidationResponse(
-            status = "VALID",
-            holderName = "Иван Иванов",
-            seat = "Партер, ряд 3, место 7"
-        )
-        "t-002" -> TicketValidationResponse(
-            status = "VALID",
-            holderName = "Мария Смирнова",
-            seat = "Партер, ряд 1, место 12"
-        )
-        "t-003" -> TicketValidationResponse(
-            status = "ALREADY_USED",
-            holderName = "Пётр Петров",
-            seat = "Ряд 5, место 9",
-            usedAt = "2026-03-02T14:05:00Z"
-        )
-        "t-999" -> TicketValidationResponse(
-            status = "WRONG_EVENT",
-            ticketEventLabel = "Другое мероприятие",
-            scannedEventLabel = orgEvents.find { it.id == eventId }?.label ?: eventId
-        )
-        else -> TicketValidationResponse(status = "NOT_FOUND")
-    }
+    override suspend fun validateTicket(eventId: String, ticketId: String): TicketValidationResponse =
+        when (ticketId.trim().lowercase()) {
+            "t-001" -> TicketValidationResponse(status = "VALID", holderName = "Иван Иванов", seat = "Партер, ряд 3, место 7")
+            "t-002" -> TicketValidationResponse(status = "VALID", holderName = "Мария Смирнова", seat = "Партер, ряд 1, место 12")
+            "t-003" -> TicketValidationResponse(status = "ALREADY_USED", holderName = "Пётр Петров", seat = "Ряд 5, место 9", usedAt = "2026-03-02T14:05:00Z")
+            "t-999" -> TicketValidationResponse(
+                status = "WRONG_EVENT",
+                ticketEventLabel = "Другое мероприятие",
+                scannedEventLabel = orgEvents.find { it.id == eventId }?.label ?: eventId
+            )
+            else -> TicketValidationResponse(status = "NOT_FOUND")
+        }
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeTicketService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeTicketService.kt
@@ -2,52 +2,12 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.TicketDto
 
-/**
- * Мок-реализация для разработки без бекенда.
- * Возвращает 4 тестовых билета: 2 актуальных и 2 архивных.
- */
 class FakeTicketService : TicketService {
 
-    override suspend fun getMyTickets(authToken: String): List<TicketDto> = listOf(
-        TicketDto(
-            id = "t-001",
-            eventId = "e-001",
-            eventLabel = "Лебединое озеро",
-            seat = "Партер, ряд 3, место 7",
-            price = 2000,
-            usedAt = null,
-            venueName = "Большой театр",
-            eventTime = "5 апр 2026, 15:00"
-        ),
-        TicketDto(
-            id = "t-002",
-            eventId = "e-002",
-            eventLabel = "Вечеринка 90-х",
-            seat = "Партер, ряд 1, место 12",
-            price = 1200,
-            usedAt = null,
-            venueName = "Арена",
-            eventTime = "3 апр 2026, 18:00"
-        ),
-        TicketDto(
-            id = "t-003",
-            eventId = "e-003",
-            eventLabel = "Дюна: Часть вторая",
-            seat = "Ряд 5, место 9",
-            price = 350,
-            usedAt = "2026-03-02T14:00:00Z",
-            venueName = "Кинотеатр Октябрь",
-            eventTime = "2 мар 2026, 14:00"
-        ),
-        TicketDto(
-            id = "t-004",
-            eventId = "e-004",
-            eventLabel = "Вечер стендапа",
-            seat = "Балкон, место 4",
-            price = 900,
-            usedAt = "2026-02-15T19:00:00Z",
-            venueName = "Известия Hall",
-            eventTime = "15 фев 2026, 19:00"
-        )
+    override suspend fun getMyTickets(): List<TicketDto> = listOf(
+        TicketDto(id = "t-001", eventId = "e-001", eventLabel = "Лебединое озеро", seat = "Партер, ряд 3, место 7", price = 2000, usedAt = null, venueName = "Большой театр", eventTime = "5 апр 2026, 15:00"),
+        TicketDto(id = "t-002", eventId = "e-002", eventLabel = "Вечеринка 90-х", seat = "Партер, ряд 1, место 12", price = 1200, usedAt = null, venueName = "Арена", eventTime = "3 апр 2026, 18:00"),
+        TicketDto(id = "t-003", eventId = "e-003", eventLabel = "Дюна: Часть вторая", seat = "Ряд 5, место 9", price = 350, usedAt = "2026-03-02T14:00:00Z", venueName = "Кинотеатр Октябрь", eventTime = "2 мар 2026, 14:00"),
+        TicketDto(id = "t-004", eventId = "e-004", eventLabel = "Вечер стендапа", seat = "Балкон, место 4", price = 900, usedAt = "2026-02-15T19:00:00Z", venueName = "Известия Hall", eventTime = "15 фев 2026, 19:00")
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueAccessGrantService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueAccessGrantService.kt
@@ -5,49 +5,31 @@ import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 class FakeVenueAccessGrantService : VenueAccessGrantService {
 
     private val incoming = mutableListOf(
-        VenueAccessGrantDto(
-            id = "grant-1",
-            venueId = "venue-1",
-            requestingOrgId = "org-2",
-            status = "PENDING",
-            createdAt = "2026-04-24T10:00:00Z"
-        )
+        VenueAccessGrantDto(id = "grant-1", venueId = "venue-1", requestingOrgId = "org-2", status = "PENDING", createdAt = "2026-04-24T10:00:00Z")
     )
 
     private val outgoing = mutableListOf(
-        VenueAccessGrantDto(
-            id = "grant-2",
-            venueId = "venue-ext-1",
-            requestingOrgId = "org-1",
-            status = "PENDING",
-            createdAt = "2026-04-23T09:00:00Z"
-        )
+        VenueAccessGrantDto(id = "grant-2", venueId = "venue-ext-1", requestingOrgId = "org-1", status = "PENDING", createdAt = "2026-04-23T09:00:00Z")
     )
 
-    override suspend fun getIncomingRequests(authToken: String): List<VenueAccessGrantDto> = incoming.toList()
+    override suspend fun getIncomingRequests(): List<VenueAccessGrantDto> = incoming.toList()
 
-    override suspend fun getOutgoingRequests(authToken: String): List<VenueAccessGrantDto> = outgoing.toList()
+    override suspend fun getOutgoingRequests(): List<VenueAccessGrantDto> = outgoing.toList()
 
-    override suspend fun requestAccess(authToken: String, venueId: String, requestingOrgId: String): VenueAccessGrantDto {
-        val grant = VenueAccessGrantDto(
-            id = "grant-new-${outgoing.size}",
-            venueId = venueId,
-            requestingOrgId = requestingOrgId,
-            status = "PENDING",
-            createdAt = "2026-04-25T10:00:00Z"
-        )
+    override suspend fun requestAccess(venueId: String, requestingOrgId: String): VenueAccessGrantDto {
+        val grant = VenueAccessGrantDto(id = "grant-new-${outgoing.size}", venueId = venueId, requestingOrgId = requestingOrgId, status = "PENDING", createdAt = "2026-04-25T10:00:00Z")
         outgoing.add(grant)
         return grant
     }
 
-    override suspend fun approve(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto {
+    override suspend fun approve(venueId: String, grantId: String): VenueAccessGrantDto {
         val index = incoming.indexOfFirst { it.id == grantId }
         val updated = incoming[index].copy(status = "APPROVED")
         incoming[index] = updated
         return updated
     }
 
-    override suspend fun reject(authToken: String, venueId: String, grantId: String): VenueAccessGrantDto {
+    override suspend fun reject(venueId: String, grantId: String): VenueAccessGrantDto {
         val index = incoming.indexOfFirst { it.id == grantId }
         val updated = incoming[index].copy(status = "REJECTED")
         incoming[index] = updated

--- a/composeApp/src/mockTest/kotlin/com/karrad/ticketsclient/data/api/FakeProfileServiceTest.kt
+++ b/composeApp/src/mockTest/kotlin/com/karrad/ticketsclient/data/api/FakeProfileServiceTest.kt
@@ -28,7 +28,6 @@ class FakeProfileServiceTest {
     @Test
     fun `updateProfile returns updated fullName`() = runTest {
         val result = service.updateProfile(
-            authToken = "fake-token",
             fullName = "Новое Имя",
             interests = null
         )
@@ -38,7 +37,6 @@ class FakeProfileServiceTest {
     @Test
     fun `updateProfile keeps existing fullName when null`() = runTest {
         val result = service.updateProfile(
-            authToken = "fake-token",
             fullName = null,
             interests = null
         )
@@ -48,7 +46,6 @@ class FakeProfileServiceTest {
     @Test
     fun `updateProfile returns updated interests`() = runTest {
         val result = service.updateProfile(
-            authToken = "fake-token",
             fullName = null,
             interests = listOf("classical", "rock")
         )
@@ -58,7 +55,6 @@ class FakeProfileServiceTest {
     @Test
     fun `updateProfile keeps existing interests when null`() = runTest {
         val result = service.updateProfile(
-            authToken = "fake-token",
             fullName = null,
             interests = null
         )
@@ -67,14 +63,13 @@ class FakeProfileServiceTest {
 
     @Test
     fun `updateProfile returns correct userId`() = runTest {
-        val result = service.updateProfile("token", null, null)
+        val result = service.updateProfile(null, null)
         assertEquals("user-42", result.id)
     }
 
     @Test
     fun `uploadAvatar returns avatarUrl with correct extension`() = runTest {
         val result = service.uploadAvatar(
-            authToken = "fake-token",
             imageBytes = byteArrayOf(1, 2, 3),
             extension = "png"
         )
@@ -84,13 +79,13 @@ class FakeProfileServiceTest {
 
     @Test
     fun `uploadAvatar returns jpg extension`() = runTest {
-        val result = service.uploadAvatar("token", byteArrayOf(), "jpg")
+        val result = service.uploadAvatar(byteArrayOf(), "jpg")
         assertTrue(result.avatarUrl?.contains("avatar.jpg") == true)
     }
 
     @Test
     fun `uploadAvatar returns correct userId`() = runTest {
-        val result = service.uploadAvatar("token", byteArrayOf(), "jpg")
+        val result = service.uploadAvatar(byteArrayOf(), "jpg")
         assertEquals("user-42", result.id)
     }
 }


### PR DESCRIPTION
## Summary

- Добавлен `HttpSend` interceptor в `createHttpClient()` — Bearer-токен из `AppSession.authToken` инжектируется автоматически во все исходящие запросы
- Параметр `authToken` удалён из всех 8 сервисных интерфейсов, 8 API-реализаций, 8 Fake-реализаций
- Все UI-экраны очищены от ручной передачи токена: `FeedScreen`, `FavoritesScreen`, `TicketsScreen`, `ScannerScreen`, `OrderConfirmScreen`, `EditProfileScreen`, `MainScreen`, `OrgManagementScreen`, `MemberManagementScreen`, `VenueAccessScreen`, `TicketTypeScreen`, `SeatMapScreen`
- `AuthService.logout(token)` оставлен с явным параметром — вызывается после `AppSession.logout()`, когда токен уже очищен из сессии
- Обновлены тесты: `FeedViewModelTest`, `FakeProfileServiceTest`

## Test plan

- [ ] Mock-сборка компилируется без ошибок
- [ ] Prod-сборка компилируется без ошибок
- [ ] `./gradlew :composeApp:testMockDebugUnitTest` — все тесты зелёные
- [ ] `./gradlew :composeApp:testDebugUnitTest` — все тесты зелёные

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)