### PR TITLE
fix(#130): CrashReporter.log во все catch-блоки в UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.CityDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.InterestsScreen
@@ -48,7 +49,7 @@ fun CitySelectionScreen(onCitySelected: ((String) -> Unit)? = null) {
     var selectedCity by remember { mutableStateOf<CityDto?>(null) }
 
     LaunchedEffect(Unit) {
-        allCities = try { AppContainer.geoService.getCities() } catch (_: Exception) { emptyList() }
+        allCities = try { AppContainer.geoService.getCities() } catch (e: Exception) { CrashReporter.log(e); emptyList() }
     }
 
     val cities = remember(query, allCities) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 import com.karrad.ticketsclient.ui.navigation.RegisterScreen
@@ -131,6 +132,7 @@ fun LoginScreen() {
                             AppContainer.authService.sendCode(phone)
                             navigator.push(SmsCodeScreen(isRegistration = false, phone = phone))
                         } catch (e: Exception) {
+                            CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."
                         } finally {
                             loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.CitySelectionScreen
 import kotlinx.coroutines.launch
@@ -105,6 +106,7 @@ fun NameInputScreen(phone: String = "", code: String = "") {
                         )
                         navigator.push(CitySelectionScreen)
                     } catch (e: Exception) {
+                        CrashReporter.log(e)
                         error = "Ошибка регистрации. Попробуйте ещё раз."
                     } finally {
                         loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.SmsCodeScreen
 import kotlinx.coroutines.launch
@@ -105,6 +106,7 @@ fun RegisterScreen() {
                             AppContainer.authService.sendCode(phone)
                             navigator.push(SmsCodeScreen(isRegistration = true, phone = phone))
                         } catch (e: Exception) {
+                            CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."
                         } finally {
                             loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
@@ -35,6 +35,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import androidx.compose.ui.text.style.TextAlign
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 import com.karrad.ticketsclient.ui.navigation.NameInputScreen
@@ -128,6 +129,7 @@ fun SmsCodeScreen(isRegistration: Boolean = false, phone: String = "") {
                             navigator.replaceAll(MainScreen)
                         }
                     } catch (e: Exception) {
+                        CrashReporter.log(e)
                         error = "Неверный код. Попробуйте ещё раз."
                     } finally {
                         loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.LaunchedEffect
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.SeatMapScreen
@@ -76,7 +77,7 @@ fun EventDetailScreen(eventId: String) {
     )
 
     LaunchedEffect(eventId) {
-        loadedEvent = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
+        loadedEvent = try { AppContainer.eventService.getEvent(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
     }
 
     val event = loadedEvent ?: run {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -60,6 +60,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.CategoryEventsEntryDto
 import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
 import com.karrad.ticketsclient.data.api.dto.EventDto
@@ -552,6 +553,7 @@ private fun EventCard(
                                 if (newFav) AppContainer.favoriteService.add(event.id)
                                 else AppContainer.favoriteService.remove(event.id)
                             }.onFailure {
+                                CrashReporter.log(it)
                                 // rollback on error
                                 isFav = !newFav
                                 AppSession.toggleFavorite(event.id, !newFav)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/main/MainScreen.kt
@@ -63,7 +63,7 @@ fun MainScreen() {
             val membership = try {
                 AppContainer.orgMemberService.getMyMembership()
             } catch (e: Exception) {
-                println("MainScreen: не удалось получить членство — ${e.message}")
+                CrashReporter.log(e)
                 null
             }
             AppSession.orgMembership = membership

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/order/OrderConfirmScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
@@ -56,13 +57,13 @@ fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
     var success by remember { mutableStateOf(false) }
 
     LaunchedEffect(eventId) {
-        event = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
+        event = try { AppContainer.eventService.getEvent(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
     }
 
     LaunchedEffect(orderId) {
         try {
             orderStatus = AppContainer.orderService.getOrder(orderId).status
-        } catch (_: Exception) { }
+        } catch (e: Exception) { CrashReporter.log(e) }
     }
 
     Column(
@@ -177,6 +178,7 @@ fun OrderConfirmScreen(eventId: String, orderId: String, totalPrice: Int) {
                             AppContainer.orderService.confirmPayment(orderId)
                             success = true
                         } catch (e: Exception) {
+                            CrashReporter.log(e)
                             error = "Ошибка оплаты. Попробуйте ещё раз."
                         } finally {
                             loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -65,6 +66,7 @@ fun MemberManagementScreen() {
                 members = AppContainer.orgMemberService.listMembers()
                     .filter { it.role == "STAFF" }
             } catch (e: Exception) {
+                CrashReporter.log(e)
                 error = e.message
             } finally {
                 isLoading = false
@@ -127,6 +129,7 @@ fun MemberManagementScreen() {
                         onDelete = {
                             scope.launch {
                                 runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
+                                    .onFailure { CrashReporter.log(it) }
                                 loadMembers()
                             }
                         }
@@ -166,7 +169,7 @@ fun MemberManagementScreen() {
                                 role = "STAFF",
                                 venueId = addVenueId.trim().ifBlank { null }
                             )
-                        }
+                        }.onFailure { CrashReporter.log(it) }
                         showAddDialog = false
                         addUserId = ""
                         addVenueId = ""

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -76,6 +77,7 @@ fun OrgManagementScreen() {
             try {
                 members = AppContainer.orgMemberService.listMembers()
             } catch (e: Exception) {
+                CrashReporter.log(e)
                 error = e.message
             } finally {
                 isLoading = false
@@ -133,6 +135,7 @@ fun OrgManagementScreen() {
                         onDelete = {
                             scope.launch {
                                 runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
+                                    .onFailure { CrashReporter.log(it) }
                                 loadMembers()
                             }
                         }
@@ -198,7 +201,7 @@ fun OrgManagementScreen() {
                                 role = addRole,
                                 venueId = addVenueId.trim().ifBlank { null }
                             )
-                        }
+                        }.onFailure { CrashReporter.log(it) }
                         showAddDialog = false
                         addUserId = ""
                         addRole = "MANAGER"

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
@@ -65,6 +66,7 @@ fun VenueAccessScreen() {
                 incoming = AppContainer.venueAccessGrantService.getIncomingRequests()
                 outgoing = AppContainer.venueAccessGrantService.getOutgoingRequests()
             } catch (e: Exception) {
+                CrashReporter.log(e)
                 error = e.message
             } finally {
                 isLoading = false
@@ -136,7 +138,7 @@ fun VenueAccessScreen() {
                                     scope.launch {
                                         runCatching {
                                             AppContainer.venueAccessGrantService.approve(grant.venueId, grant.id)
-                                        }
+                                        }.onFailure { CrashReporter.log(it) }
                                         load()
                                     }
                                 },
@@ -144,7 +146,7 @@ fun VenueAccessScreen() {
                                     scope.launch {
                                         runCatching {
                                             AppContainer.venueAccessGrantService.reject(grant.venueId, grant.id)
-                                        }
+                                        }.onFailure { CrashReporter.log(it) }
                                         load()
                                     }
                                 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
 
@@ -191,6 +192,7 @@ fun EditProfileScreen() {
                             AppSession.city = city.trim().ifBlank { AppSession.city }
                             navigator.pop()
                         } catch (e: Exception) {
+                            CrashReporter.log(e)
                             saveError = "Ошибка сохранения: ${e.message}"
                         } finally {
                             saving = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/FavoritesScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
@@ -61,6 +62,7 @@ fun FavoritesScreen() {
                 AppSession.setFavorites(list.map { it.id })
             }
             .onFailure {
+                CrashReporter.log(it)
                 favorites = AppSession.cachedEvents.filter { AppSession.isFavorite(it.id) }
             }
         loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.TicketValidationResponse
 import com.karrad.ticketsclient.di.AppContainer
@@ -78,6 +79,7 @@ fun ScannerScreen() {
             val events = AppContainer.scannerService.getMyOrgEvents()
             state = if (events.isEmpty()) ScannerState.NoAccess else ScannerState.EventList(events)
         } catch (e: Exception) {
+            CrashReporter.log(e)
             state = ScannerState.NoAccess
         }
     }
@@ -112,6 +114,7 @@ fun ScannerScreen() {
                             )
                             state = s.copy(validating = false, result = result)
                         } catch (e: Exception) {
+                            CrashReporter.log(e)
                             state = s.copy(
                                 validating = false,
                                 result = TicketValidationResponse(status = "NOT_FOUND")

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
@@ -69,7 +70,8 @@ fun SearchScreen() {
         loading = true
         results = try {
             AppContainer.eventService.search(query, AppSession.city)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            CrashReporter.log(e)
             emptyList()
         } finally {
             loading = false

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
@@ -60,6 +60,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import androidx.compose.runtime.LaunchedEffect
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatKeyRequestDto
@@ -100,8 +101,8 @@ fun SeatMapScreen(eventId: String) {
     var seatMap by remember { mutableStateOf<SeatMapDto?>(null) }
 
     LaunchedEffect(eventId) {
-        event = try { AppContainer.eventService.getEvent(eventId) } catch (_: Exception) { null }
-        seatMap = try { AppContainer.eventService.getSeatMap(eventId) } catch (_: Exception) { null }
+        event = try { AppContainer.eventService.getEvent(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
+        seatMap = try { AppContainer.eventService.getSeatMap(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
     }
 
     val allSeats = remember(seatMap) { seatMap?.toSeats() ?: emptyList() }
@@ -331,7 +332,8 @@ fun SeatMapScreen(eventId: String) {
                                                 totalPrice = totalPrice
                                             )
                                         )
-                                    } catch (_: Exception) {
+                                    } catch (e: Exception) {
+                                        CrashReporter.log(e)
                                     } finally {
                                         buyLoading = false
                                     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.TicketDto
 import com.karrad.ticketsclient.di.AppContainer
@@ -69,7 +70,8 @@ fun TicketsScreen() {
             AppSession.cachedTickets = loaded   // обновляем кеш при успехе
             AppSession.isOffline = false
             isFromCache = false
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            CrashReporter.log(e)
             // Нет сети — показываем кешированные билеты
             if (AppSession.cachedTickets.isNotEmpty()) {
                 tickets = AppSession.cachedTickets

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.AdmissionInventoryItemRequestDto
 import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -77,6 +78,7 @@ fun TicketTypeScreen(eventId: String) {
             ticketTypes = AppContainer.eventService.getTicketTypes(eventId)
             ticketTypes.forEach { quantities[it.id] = 0 }
         } catch (e: Exception) {
+            CrashReporter.log(e)
             loadError = e.message ?: "Не удалось загрузить типы билетов"
         } finally {
             loading = false
@@ -284,7 +286,8 @@ fun TicketTypeScreen(eventId: String) {
                                             totalPrice = totalPrice
                                         )
                                     )
-                                } catch (_: Exception) {
+                                } catch (e: Exception) {
+                                    CrashReporter.log(e)
                                 } finally {
                                     buyLoading = false
                                 }


### PR DESCRIPTION
## Summary

- Добавлен `CrashReporter.log(e)` во все `catch (e: Exception)` блоки в UI-слое — auth, org, scanner, order, profile, feed, search, seatmap
- Немые `catch (_: Exception)` для сетевых вызовов переименованы и залогированы
- `runCatching` блоки дополнены `.onFailure { CrashReporter.log(it) }` — favorites list/add/remove, org member delete/add, venue approve/reject
- Исключение: `Instant.parse` (парсинг даты) и `loadMore` в FeedViewModel остаются тихими — намеренное поведение

## Test plan

- [ ] Mock-сборка компилируется без ошибок
- [ ] `./gradlew :composeApp:testMockDebugUnitTest` — все тесты зелёные

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)