### PR TITLE
refactor(#128): ViewModel для org-экранов

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -27,54 +27,29 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.crash.CrashReporter
-import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
-import kotlinx.coroutines.launch
 
 @Composable
 fun MemberManagementScreen() {
     val navigator = LocalNavigator.currentOrThrow
-    val scope = rememberCoroutineScope()
-
-    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
-    var error by remember { mutableStateOf<String?>(null) }
+    val vm = viewModel { MemberManagementViewModel(AppContainer.orgMemberService) }
+    val state by vm.state.collectAsState()
 
     var showAddDialog by remember { mutableStateOf(false) }
     var addUserId by remember { mutableStateOf("") }
     var addVenueId by remember { mutableStateOf("") }
-
-    fun loadMembers() {
-        scope.launch {
-            isLoading = true
-            error = null
-            try {
-                // MANAGER видит только STAFF
-                members = AppContainer.orgMemberService.listMembers()
-                    .filter { it.role == "STAFF" }
-            } catch (e: Exception) {
-                CrashReporter.log(e)
-                error = e.message
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    LaunchedEffect(Unit) { loadMembers() }
 
     Column(
         modifier = Modifier
@@ -102,13 +77,13 @@ fun MemberManagementScreen() {
         }
 
         when {
-            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
-            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
             }
-            members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            state.members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(
                     "Сотрудников пока нет",
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -122,17 +97,11 @@ fun MemberManagementScreen() {
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 item { Spacer(Modifier.height(8.dp)) }
-                items(members) { member ->
+                items(state.members) { member ->
                     MemberRow(
                         member = member,
                         canDelete = true,
-                        onDelete = {
-                            scope.launch {
-                                runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
-                                    .onFailure { CrashReporter.log(it) }
-                                loadMembers()
-                            }
-                        }
+                        onDelete = { vm.deleteMember(member.id) }
                     )
                 }
                 item { Spacer(Modifier.height(96.dp)) }
@@ -162,19 +131,13 @@ fun MemberManagementScreen() {
             },
             confirmButton = {
                 Button(onClick = {
-                    scope.launch {
-                        runCatching {
-                            AppContainer.orgMemberService.addMember(
-                                userId = addUserId.trim(),
-                                role = "STAFF",
-                                venueId = addVenueId.trim().ifBlank { null }
-                            )
-                        }.onFailure { CrashReporter.log(it) }
-                        showAddDialog = false
-                        addUserId = ""
-                        addVenueId = ""
-                        loadMembers()
-                    }
+                    vm.addMember(
+                        userId = addUserId.trim(),
+                        venueId = addVenueId.trim().ifBlank { null }
+                    )
+                    showAddDialog = false
+                    addUserId = ""
+                    addVenueId = ""
                 }) { Text("Добавить") }
             },
             dismissButton = {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementViewModel.kt
@@ -1,0 +1,58 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.OrgMemberService
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class MemberManagementState(
+    val members: List<OrgMemberDto> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null
+)
+
+class MemberManagementViewModel(
+    private val orgMemberService: OrgMemberService
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(MemberManagementState())
+    val state: StateFlow<MemberManagementState> = _state.asStateFlow()
+
+    init {
+        loadMembers()
+    }
+
+    fun loadMembers() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            try {
+                val staff = orgMemberService.listMembers().filter { it.role == "STAFF" }
+                _state.value = MemberManagementState(members = staff)
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = MemberManagementState(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun deleteMember(memberId: String) {
+        viewModelScope.launch {
+            runCatching { orgMemberService.deleteMember(memberId) }
+                .onFailure { CrashReporter.log(it) }
+            loadMembers()
+        }
+    }
+
+    fun addMember(userId: String, venueId: String?) {
+        viewModelScope.launch {
+            runCatching { orgMemberService.addMember(userId = userId, role = "STAFF", venueId = venueId) }
+                .onFailure { CrashReporter.log(it) }
+            loadMembers()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -35,57 +35,34 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OrgManagementScreen() {
     val navigator = LocalNavigator.currentOrThrow
-    val scope = rememberCoroutineScope()
+    val vm = viewModel { OrgManagementViewModel(AppContainer.orgMemberService) }
+    val state by vm.state.collectAsState()
 
-    var members by remember { mutableStateOf<List<OrgMemberDto>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
-    var error by remember { mutableStateOf<String?>(null) }
-
-    // Add member dialog state
     var showAddDialog by remember { mutableStateOf(false) }
     var addUserId by remember { mutableStateOf("") }
     var addRole by remember { mutableStateOf("MANAGER") }
     var addVenueId by remember { mutableStateOf("") }
     var roleMenuExpanded by remember { mutableStateOf(false) }
-
-    fun loadMembers() {
-        scope.launch {
-            isLoading = true
-            error = null
-            try {
-                members = AppContainer.orgMemberService.listMembers()
-            } catch (e: Exception) {
-                CrashReporter.log(e)
-                error = e.message
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    LaunchedEffect(Unit) { loadMembers() }
 
     Column(
         modifier = Modifier
@@ -93,7 +70,6 @@ fun OrgManagementScreen() {
             .background(MaterialTheme.colorScheme.background)
             .statusBarsPadding()
     ) {
-        // Toolbar
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -114,11 +90,11 @@ fun OrgManagementScreen() {
         }
 
         when {
-            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
-            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
             }
             else -> LazyColumn(
                 modifier = Modifier
@@ -128,17 +104,11 @@ fun OrgManagementScreen() {
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 item { Spacer(Modifier.height(8.dp)) }
-                items(members) { member ->
+                items(state.members) { member ->
                     MemberRow(
                         member = member,
                         canDelete = true,
-                        onDelete = {
-                            scope.launch {
-                                runCatching { AppContainer.orgMemberService.deleteMember(member.id) }
-                                    .onFailure { CrashReporter.log(it) }
-                                loadMembers()
-                            }
-                        }
+                        onDelete = { vm.deleteMember(member.id) }
                     )
                 }
                 item { Spacer(Modifier.height(96.dp)) }
@@ -194,20 +164,15 @@ fun OrgManagementScreen() {
             },
             confirmButton = {
                 Button(onClick = {
-                    scope.launch {
-                        runCatching {
-                            AppContainer.orgMemberService.addMember(
-                                userId = addUserId.trim(),
-                                role = addRole,
-                                venueId = addVenueId.trim().ifBlank { null }
-                            )
-                        }.onFailure { CrashReporter.log(it) }
-                        showAddDialog = false
-                        addUserId = ""
-                        addRole = "MANAGER"
-                        addVenueId = ""
-                        loadMembers()
-                    }
+                    vm.addMember(
+                        userId = addUserId.trim(),
+                        role = addRole,
+                        venueId = addVenueId.trim().ifBlank { null }
+                    )
+                    showAddDialog = false
+                    addUserId = ""
+                    addRole = "MANAGER"
+                    addVenueId = ""
                 }) { Text("Добавить") }
             },
             dismissButton = {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
@@ -1,0 +1,57 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.OrgMemberService
+import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class OrgManagementState(
+    val members: List<OrgMemberDto> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null
+)
+
+class OrgManagementViewModel(
+    private val orgMemberService: OrgMemberService
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(OrgManagementState())
+    val state: StateFlow<OrgManagementState> = _state.asStateFlow()
+
+    init {
+        loadMembers()
+    }
+
+    fun loadMembers() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            try {
+                _state.value = OrgManagementState(members = orgMemberService.listMembers())
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = OrgManagementState(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun deleteMember(memberId: String) {
+        viewModelScope.launch {
+            runCatching { orgMemberService.deleteMember(memberId) }
+                .onFailure { CrashReporter.log(it) }
+            loadMembers()
+        }
+    }
+
+    fun addMember(userId: String, role: String, venueId: String?) {
+        viewModelScope.launch {
+            runCatching { orgMemberService.addMember(userId = userId, role = role, venueId = venueId) }
+                .onFailure { CrashReporter.log(it) }
+            loadMembers()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
@@ -28,53 +28,29 @@ import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 import com.karrad.ticketsclient.di.AppContainer
-import kotlinx.coroutines.launch
 
 @Composable
 fun VenueAccessScreen() {
     val navigator = LocalNavigator.currentOrThrow
-    val scope = rememberCoroutineScope()
+    val vm = viewModel { VenueAccessViewModel(AppContainer.venueAccessGrantService) }
+    val state by vm.state.collectAsState()
+
     var selectedTab by remember { mutableIntStateOf(0) }
-
-    var incoming by remember { mutableStateOf<List<VenueAccessGrantDto>>(emptyList()) }
-    var outgoing by remember { mutableStateOf<List<VenueAccessGrantDto>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
-    var error by remember { mutableStateOf<String?>(null) }
-
-    fun load() {
-        scope.launch {
-            isLoading = true
-            error = null
-            try {
-                incoming = AppContainer.venueAccessGrantService.getIncomingRequests()
-                outgoing = AppContainer.venueAccessGrantService.getOutgoingRequests()
-            } catch (e: Exception) {
-                CrashReporter.log(e)
-                error = e.message
-            } finally {
-                isLoading = false
-            }
-        }
-    }
-
-    LaunchedEffect(Unit) { load() }
 
     Column(
         modifier = Modifier
@@ -99,20 +75,20 @@ fun VenueAccessScreen() {
 
         ScrollableTabRow(selectedTabIndex = selectedTab, edgePadding = 16.dp) {
             Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 },
-                text = { Text("Входящие (${incoming.size})") })
+                text = { Text("Входящие (${state.incoming.size})") })
             Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
-                text = { Text("Исходящие (${outgoing.size})") })
+                text = { Text("Исходящие (${state.outgoing.size})") })
         }
 
         when {
-            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
-            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
             }
             else -> {
-                val items = if (selectedTab == 0) incoming else outgoing
+                val items = if (selectedTab == 0) state.incoming else state.outgoing
                 if (items.isEmpty()) {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text(
@@ -134,22 +110,8 @@ fun VenueAccessScreen() {
                             GrantCard(
                                 grant = grant,
                                 isIncoming = selectedTab == 0,
-                                onApprove = {
-                                    scope.launch {
-                                        runCatching {
-                                            AppContainer.venueAccessGrantService.approve(grant.venueId, grant.id)
-                                        }.onFailure { CrashReporter.log(it) }
-                                        load()
-                                    }
-                                },
-                                onReject = {
-                                    scope.launch {
-                                        runCatching {
-                                            AppContainer.venueAccessGrantService.reject(grant.venueId, grant.id)
-                                        }.onFailure { CrashReporter.log(it) }
-                                        load()
-                                    }
-                                }
+                                onApprove = { vm.approve(grant.venueId, grant.id) },
+                                onReject = { vm.reject(grant.venueId, grant.id) }
                             )
                         }
                         item { Spacer(Modifier.height(96.dp)) }
@@ -168,7 +130,7 @@ private fun GrantCard(
     onReject: () -> Unit
 ) {
     Column(
-        modifier = androidx.compose.ui.Modifier
+        modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
@@ -176,7 +138,7 @@ private fun GrantCard(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Row(
-            modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -198,12 +160,12 @@ private fun GrantCard(
         )
         if (isIncoming && grant.status == "PENDING") {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(onClick = onApprove, modifier = androidx.compose.ui.Modifier.weight(1f)) {
+                Button(onClick = onApprove, modifier = Modifier.weight(1f)) {
                     Text("Одобрить")
                 }
                 OutlinedButton(
                     onClick = onReject,
-                    modifier = androidx.compose.ui.Modifier.weight(1f),
+                    modifier = Modifier.weight(1f),
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.error
                     )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessViewModel.kt
@@ -1,0 +1,61 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.VenueAccessGrantService
+import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class VenueAccessState(
+    val incoming: List<VenueAccessGrantDto> = emptyList(),
+    val outgoing: List<VenueAccessGrantDto> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null
+)
+
+class VenueAccessViewModel(
+    private val venueAccessGrantService: VenueAccessGrantService
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(VenueAccessState())
+    val state: StateFlow<VenueAccessState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            try {
+                _state.value = VenueAccessState(
+                    incoming = venueAccessGrantService.getIncomingRequests(),
+                    outgoing = venueAccessGrantService.getOutgoingRequests()
+                )
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = VenueAccessState(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun approve(venueId: String, grantId: String) {
+        viewModelScope.launch {
+            runCatching { venueAccessGrantService.approve(venueId, grantId) }
+                .onFailure { CrashReporter.log(it) }
+            load()
+        }
+    }
+
+    fun reject(venueId: String, grantId: String) {
+        viewModelScope.launch {
+            runCatching { venueAccessGrantService.reject(venueId, grantId) }
+                .onFailure { CrashReporter.log(it) }
+            load()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Создан `OrgManagementViewModel` — listMembers, deleteMember, addMember
- Создан `MemberManagementViewModel` — listMembers (фильтр STAFF), deleteMember, addMember
- Создан `VenueAccessViewModel` — load (incoming/outgoing), approve, reject
- Composable-экраны полностью очищены от бизнес-логики: только `collectAsState()` + вызовы методов VM
- Диалоговые состояния (showAddDialog, addUserId и т.д.) остались в Composable — это чистый UI-стейт
- Все три VM используют `viewModelScope` + `StateFlow`, по образцу `FeedViewModel`

## Test plan

- [ ] Mock-сборка компилируется без ошибок
- [ ] Prod-сборка компилируется без ошибок
- [ ] Открыть OrgManagementScreen, MemberManagementScreen, VenueAccessScreen — данные загружаются
- [ ] Ротация экрана не сбрасывает состояние

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)