### PR TITLE
feat(#134,#135,#136,#137): org UI — VenueApplication, by-phone member, venue rental request, leave org

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
@@ -1,9 +1,12 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneRequest
+import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneResponse
 import com.karrad.ticketsclient.data.api.dto.AddMemberRequest
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.api.dto.UpdateMemberRequest
+import com.karrad.ticketsclient.data.api.dto.VenueDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -28,6 +31,15 @@ class OrgMemberApiService(
     override suspend fun listMembers(): List<OrgMemberDto> =
         httpClient.get("$baseUrl/api/v1/my/organization/members").body()
 
+    override suspend fun listMyVenues(): List<VenueDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/venues").body()
+
+    override suspend fun addMemberByPhone(phone: String, role: String, venueId: String?): AddMemberByPhoneResponse =
+        httpClient.post("$baseUrl/api/v1/my/organization/members/by-phone") {
+            contentType(ContentType.Application.Json)
+            setBody(AddMemberByPhoneRequest(phone = phone, role = role, venueId = venueId))
+        }.body()
+
     override suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto =
         httpClient.post("$baseUrl/api/v1/my/organization/members") {
             contentType(ContentType.Application.Json)
@@ -42,5 +54,9 @@ class OrgMemberApiService(
 
     override suspend fun deleteMember(memberId: String) {
         httpClient.delete("$baseUrl/api/v1/my/organization/members/$memberId")
+    }
+
+    override suspend fun leaveOrganization() {
+        httpClient.delete("$baseUrl/api/v1/my/organization/membership")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
@@ -1,7 +1,10 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneRequest
+import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneResponse
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
+import com.karrad.ticketsclient.data.api.dto.VenueDto
 
 interface OrgMemberService {
     /** Возвращает членство текущего пользователя в организации, или null если не состоит. */
@@ -10,12 +13,21 @@ interface OrgMemberService {
     /** Список членов организации (требует OWNER или MANAGER). */
     suspend fun listMembers(): List<OrgMemberDto>
 
+    /** Список площадок организации текущего пользователя. */
+    suspend fun listMyVenues(): List<VenueDto>
+
     /** Добавить участника (OWNER — любую роль; MANAGER — только STAFF). */
     suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto
+
+    /** Добавить участника по номеру телефона. Создаёт аккаунт если не найден. */
+    suspend fun addMemberByPhone(phone: String, role: String, venueId: String?): AddMemberByPhoneResponse
 
     /** Обновить роль/venue участника (только OWNER). */
     suspend fun updateMember(memberId: String, role: String, venueId: String?): OrgMemberDto
 
     /** Удалить участника (OWNER — любого; MANAGER — только STAFF). */
     suspend fun deleteMember(memberId: String)
+
+    /** Покинуть организацию (текущий пользователь). */
+    suspend fun leaveOrganization()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationApiService.kt
@@ -1,0 +1,26 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
+import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+
+class VenueApplicationApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : VenueApplicationService {
+
+    override suspend fun submit(request: CreateVenueApplicationRequest): VenueApplicationDto =
+        httpClient.post("$baseUrl/api/v1/my/organization/venue-applications") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
+
+    override suspend fun listMine(): List<VenueApplicationDto> =
+        httpClient.get("$baseUrl/api/v1/my/organization/venue-applications").body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationService.kt
@@ -1,0 +1,9 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
+import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
+
+interface VenueApplicationService {
+    suspend fun submit(request: CreateVenueApplicationRequest): VenueApplicationDto
+    suspend fun listMine(): List<VenueApplicationDto>
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
@@ -31,3 +31,24 @@ data class UpdateMemberRequest(
     val role: String,
     val venueId: String? = null
 )
+
+@Serializable
+data class AddMemberByPhoneRequest(
+    val phone: String,
+    val role: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class AddMemberByPhoneResponse(
+    val member: OrgMemberDto,
+    val accountCreated: Boolean
+)
+
+@Serializable
+data class VenueDto(
+    val id: String,
+    val label: String,
+    val address: String? = null,
+    val organizationId: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
@@ -1,0 +1,27 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VenueApplicationDto(
+    val id: String,
+    val organizationId: String,
+    val name: String,
+    val cityLabel: String,
+    val subjectLabel: String,
+    val address: String,
+    val description: String? = null,
+    val documentUrls: List<String> = emptyList(),
+    val status: String,
+    val createdAt: String,
+    val venueId: String? = null
+)
+
+@Serializable
+data class CreateVenueApplicationRequest(
+    val name: String,
+    val cityLabel: String,
+    val subjectLabel: String,
+    val address: String,
+    val description: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -22,6 +22,8 @@ import com.karrad.ticketsclient.data.api.TicketApiService
 import com.karrad.ticketsclient.data.api.TicketService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantApiService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantService
+import com.karrad.ticketsclient.data.api.VenueApplicationApiService
+import com.karrad.ticketsclient.data.api.VenueApplicationService
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.createHttpClient
 
@@ -32,6 +34,9 @@ import com.karrad.ticketsclient.data.api.createHttpClient
 object AppContainer {
 
     var isMock: Boolean = false
+        private set
+
+    var baseUrl: String = ""
         private set
 
     lateinit var authService: AuthService
@@ -67,11 +72,15 @@ object AppContainer {
     lateinit var venueAccessGrantService: VenueAccessGrantService
         private set
 
+    lateinit var venueApplicationService: VenueApplicationService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
     fun init(
         isMock: Boolean,
+        baseUrl: String = "",
         httpClient: io.ktor.client.HttpClient,
         authService: AuthService,
         discoveryService: DiscoveryService,
@@ -83,9 +92,11 @@ object AppContainer {
         profileService: ProfileService,
         favoriteService: FavoriteService,
         orgMemberService: OrgMemberService,
-        venueAccessGrantService: VenueAccessGrantService
+        venueAccessGrantService: VenueAccessGrantService,
+        venueApplicationService: VenueApplicationService
     ) {
         this.isMock = isMock
+        this.baseUrl = baseUrl
         this.httpClient = httpClient
         this.authService = authService
         this.discoveryService = discoveryService
@@ -98,6 +109,7 @@ object AppContainer {
         this.favoriteService = favoriteService
         this.orgMemberService = orgMemberService
         this.venueAccessGrantService = venueAccessGrantService
+        this.venueApplicationService = venueApplicationService
     }
 }
 
@@ -105,6 +117,7 @@ fun AppContainer.initReal(baseUrl: String) {
     val client = createHttpClient { AppSession.authToken }
     init(
         isMock = false,
+        baseUrl = baseUrl,
         httpClient = client,
         authService = AuthApiService(client, baseUrl),
         discoveryService = DiscoveryApiService(client, baseUrl),
@@ -116,6 +129,7 @@ fun AppContainer.initReal(baseUrl: String) {
         profileService = ProfileApiService(client, baseUrl),
         favoriteService = FavoriteApiService(client, baseUrl),
         orgMemberService = OrgMemberApiService(client, baseUrl),
-        venueAccessGrantService = VenueAccessGrantApiService(client, baseUrl)
+        venueAccessGrantService = VenueAccessGrantApiService(client, baseUrl),
+        venueApplicationService = VenueApplicationApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,6 +62,7 @@ import com.karrad.ticketsclient.ui.navigation.TicketTypeScreen
 import com.karrad.ticketsclient.ui.component.EventImage
 import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
 import com.karrad.ticketsclient.ui.util.formatPrice
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -68,6 +70,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun EventDetailScreen(eventId: String) {
     val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
     var loadedEvent by remember { mutableStateOf<EventDto?>(null) }
     var isFavorite by remember { mutableStateOf(AppSession.isFavorite(eventId)) }
     val favoriteColor by animateColorAsState(
@@ -150,8 +153,22 @@ fun EventDetailScreen(eventId: String) {
                             .clip(CircleShape)
                             .background(Color.White.copy(alpha = 0.85f))
                             .clickable {
-                                isFavorite = !isFavorite
-                                AppSession.toggleFavorite(eventId, isFavorite)
+                                val newFavorite = !isFavorite
+                                isFavorite = newFavorite
+                                AppSession.toggleFavorite(eventId, newFavorite)
+                                scope.launch {
+                                    runCatching {
+                                        if (newFavorite) {
+                                            AppContainer.favoriteService.add(eventId)
+                                        } else {
+                                            AppContainer.favoriteService.remove(eventId)
+                                        }
+                                    }.onFailure {
+                                        CrashReporter.log(it)
+                                        isFavorite = !newFavorite
+                                        AppSession.toggleFavorite(eventId, !newFavorite)
+                                    }
+                                }
                             },
                         contentAlignment = Alignment.Center
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementScreen.kt
@@ -14,19 +14,26 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,113 +42,173 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.screen.auth.normalizePhone
 
 @Composable
 fun MemberManagementScreen() {
     val navigator = LocalNavigator.currentOrThrow
     val vm = viewModel { MemberManagementViewModel(AppContainer.orgMemberService) }
     val state by vm.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     var showAddDialog by remember { mutableStateOf(false) }
-    var addUserId by remember { mutableStateOf("") }
+    var addPhone by remember { mutableStateOf("") }
     var addVenueId by remember { mutableStateOf("") }
+    var venueMenuExpanded by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { navigator.pop() }) {
-                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
-            }
-            Text(
-                "Сотрудники",
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.weight(1f)
+    LaunchedEffect(state.accountCreated) {
+        if (state.accountCreated) {
+            snackbarHostState.showSnackbar(
+                "Создан новый аккаунт для $addPhone",
+                duration = SnackbarDuration.Short
             )
-            IconButton(onClick = { showAddDialog = true }) {
-                Icon(Icons.Outlined.Add, contentDescription = "Добавить сотрудника")
+            vm.clearAddFeedback()
+        }
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .statusBarsPadding()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { navigator.pop() }) {
+                    Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+                }
+                Text(
+                    "Сотрудники",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { showAddDialog = true }) {
+                    Icon(Icons.Outlined.Add, contentDescription = "Добавить сотрудника")
+                }
+            }
+
+            when {
+                state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
+                }
+                state.members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Сотрудников пока нет", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                else -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .navigationBarsPadding(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    item { Spacer(Modifier.height(8.dp)) }
+                    items(state.members) { member ->
+                        MemberRow(
+                            member = member,
+                            canDelete = true,
+                            onDelete = { vm.deleteMember(member.id) }
+                        )
+                    }
+                    item { Spacer(Modifier.height(96.dp)) }
+                }
             }
         }
 
-        when {
-            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
-            }
-            state.members.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(
-                    "Сотрудников пока нет",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            else -> LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-                    .navigationBarsPadding(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                item { Spacer(Modifier.height(8.dp)) }
-                items(state.members) { member ->
-                    MemberRow(
-                        member = member,
-                        canDelete = true,
-                        onDelete = { vm.deleteMember(member.id) }
-                    )
-                }
-                item { Spacer(Modifier.height(96.dp)) }
-            }
-        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 
     if (showAddDialog) {
         AlertDialog(
-            onDismissRequest = { showAddDialog = false },
+            onDismissRequest = { showAddDialog = false; vm.clearAddFeedback() },
             title = { Text("Добавить сотрудника (STAFF)") },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = addUserId,
-                        onValueChange = { addUserId = it },
-                        label = { Text("UUID пользователя") },
-                        singleLine = true
+                        value = addPhone,
+                        onValueChange = { addPhone = it },
+                        label = { Text("Номер телефона") },
+                        placeholder = { Text("+79XXXXXXXXX") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                        modifier = Modifier.fillMaxWidth()
                     )
-                    OutlinedTextField(
-                        value = addVenueId,
-                        onValueChange = { addVenueId = it },
-                        label = { Text("UUID площадки") },
-                        singleLine = true
-                    )
+                    if (state.venues.isNotEmpty()) {
+                        val selectedVenue = state.venues.firstOrNull { it.id == addVenueId }
+                        Box {
+                            OutlinedTextField(
+                                value = selectedVenue?.label ?: "Выберите площадку",
+                                onValueChange = {},
+                                label = { Text("Площадка *") },
+                                readOnly = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            TextButton(
+                                onClick = { venueMenuExpanded = true },
+                                modifier = Modifier.fillMaxWidth()
+                            ) { Text(selectedVenue?.label ?: "Выберите площадку") }
+                            DropdownMenu(
+                                expanded = venueMenuExpanded,
+                                onDismissRequest = { venueMenuExpanded = false }
+                            ) {
+                                state.venues.forEach { venue ->
+                                    DropdownMenuItem(
+                                        text = { Text(venue.label) },
+                                        onClick = { addVenueId = venue.id; venueMenuExpanded = false }
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        OutlinedTextField(
+                            value = addVenueId,
+                            onValueChange = { addVenueId = it },
+                            label = { Text("ID площадки *") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    if (state.addError != null) {
+                        Text(
+                            text = when {
+                                state.addError!!.contains("ALREADY_MEMBER") -> "Пользователь уже состоит в организации"
+                                else -> state.addError!!
+                            },
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
                 }
             },
             confirmButton = {
-                Button(onClick = {
-                    vm.addMember(
-                        userId = addUserId.trim(),
-                        venueId = addVenueId.trim().ifBlank { null }
-                    )
-                    showAddDialog = false
-                    addUserId = ""
-                    addVenueId = ""
-                }) { Text("Добавить") }
+                Button(
+                    onClick = {
+                        val phone = normalizePhone(addPhone.trim())
+                        vm.addMemberByPhone(phone = phone, venueId = addVenueId.ifBlank { null })
+                        showAddDialog = false
+                        addPhone = ""; addVenueId = ""
+                    },
+                    enabled = addPhone.isNotBlank() && addVenueId.isNotBlank()
+                ) { Text("Добавить") }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+                TextButton(onClick = { showAddDialog = false; vm.clearAddFeedback() }) { Text("Отмена") }
             }
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/MemberManagementViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.VenueDto
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,8 +13,11 @@ import kotlinx.coroutines.launch
 
 data class MemberManagementState(
     val members: List<OrgMemberDto> = emptyList(),
+    val venues: List<VenueDto> = emptyList(),
     val isLoading: Boolean = true,
-    val error: String? = null
+    val error: String? = null,
+    val addError: String? = null,
+    val accountCreated: Boolean = false
 )
 
 class MemberManagementViewModel(
@@ -32,7 +36,8 @@ class MemberManagementViewModel(
             _state.value = _state.value.copy(isLoading = true, error = null)
             try {
                 val staff = orgMemberService.listMembers().filter { it.role == "STAFF" }
-                _state.value = MemberManagementState(members = staff)
+                val venues = try { orgMemberService.listMyVenues() } catch (_: Exception) { emptyList() }
+                _state.value = MemberManagementState(members = staff, venues = venues, isLoading = false)
             } catch (e: Exception) {
                 CrashReporter.log(e)
                 _state.value = MemberManagementState(isLoading = false, error = e.message)
@@ -54,5 +59,23 @@ class MemberManagementViewModel(
                 .onFailure { CrashReporter.log(it) }
             loadMembers()
         }
+    }
+
+    fun addMemberByPhone(phone: String, venueId: String?) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(addError = null, accountCreated = false)
+            try {
+                val result = orgMemberService.addMemberByPhone(phone = phone, role = "STAFF", venueId = venueId)
+                _state.value = _state.value.copy(accountCreated = result.accountCreated)
+                loadMembers()
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(addError = e.message)
+            }
+        }
+    }
+
+    fun clearAddFeedback() {
+        _state.value = _state.value.copy(addError = null, accountCreated = false)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -21,9 +21,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Domain
+import androidx.compose.material.icons.outlined.ExitToApp
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -31,10 +34,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,12 +52,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.screen.auth.normalizePhone
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,76 +69,144 @@ fun OrgManagementScreen() {
     val navigator = LocalNavigator.currentOrThrow
     val vm = viewModel { OrgManagementViewModel(AppContainer.orgMemberService) }
     val state by vm.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     var showAddDialog by remember { mutableStateOf(false) }
-    var addUserId by remember { mutableStateOf("") }
+    var addPhone by remember { mutableStateOf("") }
     var addRole by remember { mutableStateOf("MANAGER") }
     var addVenueId by remember { mutableStateOf("") }
     var roleMenuExpanded by remember { mutableStateOf(false) }
+    var venueMenuExpanded by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { navigator.pop() }) {
-                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
-            }
-            Text(
-                "Управление организацией",
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.weight(1f)
+    var showLeaveConfirm1 by remember { mutableStateOf(false) }
+    var showLeaveConfirm2 by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.accountCreated) {
+        if (state.accountCreated) {
+            snackbarHostState.showSnackbar(
+                "Создан новый аккаунт для $addPhone",
+                duration = SnackbarDuration.Short
             )
-            IconButton(onClick = { showAddDialog = true }) {
-                Icon(Icons.Outlined.Add, contentDescription = "Добавить участника")
-            }
-        }
-
-        when {
-            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
-            }
-            else -> LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-                    .navigationBarsPadding(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                item { Spacer(Modifier.height(8.dp)) }
-                items(state.members) { member ->
-                    MemberRow(
-                        member = member,
-                        canDelete = true,
-                        onDelete = { vm.deleteMember(member.id) }
-                    )
-                }
-                item { Spacer(Modifier.height(96.dp)) }
-            }
+            vm.clearAddError()
         }
     }
 
+    LaunchedEffect(state.leftOrg) {
+        if (state.leftOrg) navigator.pop()
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .statusBarsPadding()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { navigator.pop() }) {
+                    Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+                }
+                Text(
+                    "Управление организацией",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { showAddDialog = true }) {
+                    Icon(Icons.Outlined.Add, contentDescription = "Добавить участника")
+                }
+            }
+
+            when {
+                state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
+                }
+                else -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .navigationBarsPadding(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    item { Spacer(Modifier.height(8.dp)) }
+                    items(state.members) { member ->
+                        MemberRow(
+                            member = member,
+                            canDelete = true,
+                            onDelete = { vm.deleteMember(member.id) }
+                        )
+                    }
+                    item {
+                        OutlinedButton(
+                            onClick = { navigator.push(object : Screen {
+                                @Composable
+                                override fun Content() = VenueApplicationScreen()
+                            }) },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(Icons.Outlined.Domain, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text("Заявки на площадки")
+                        }
+                    }
+                    item {
+                        OutlinedButton(
+                            onClick = { showLeaveConfirm1 = true },
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error
+                            )
+                        ) {
+                            Icon(Icons.Outlined.ExitToApp, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text("Выйти из организации")
+                        }
+                    }
+                    if (state.leaveError != null) {
+                        item {
+                            Text(
+                                text = if (state.leaveError!!.contains("SOLE_OWNER"))
+                                    "Вы единственный владелец. Назначьте другого владельца перед выходом."
+                                else state.leaveError!!,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(horizontal = 4.dp)
+                            )
+                        }
+                    }
+                    item { Spacer(Modifier.height(96.dp)) }
+                }
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+
+    // Диалог добавления участника
     if (showAddDialog) {
         AlertDialog(
-            onDismissRequest = { showAddDialog = false },
+            onDismissRequest = { showAddDialog = false; vm.clearAddError() },
             title = { Text("Добавить участника") },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = addUserId,
-                        onValueChange = { addUserId = it },
-                        label = { Text("UUID пользователя") },
-                        singleLine = true
+                        value = addPhone,
+                        onValueChange = { addPhone = it },
+                        label = { Text("Номер телефона") },
+                        placeholder = { Text("+79XXXXXXXXX") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                        modifier = Modifier.fillMaxWidth()
                     )
                     Box {
                         OutlinedTextField(
@@ -147,36 +227,127 @@ fun OrgManagementScreen() {
                             listOf("MANAGER", "STAFF").forEach { role ->
                                 DropdownMenuItem(
                                     text = { Text(role) },
-                                    onClick = { addRole = role; roleMenuExpanded = false }
+                                    onClick = { addRole = role; addVenueId = ""; roleMenuExpanded = false }
                                 )
                             }
                         }
                     }
                     if (addRole == "STAFF") {
-                        OutlinedTextField(
-                            value = addVenueId,
-                            onValueChange = { addVenueId = it },
-                            label = { Text("UUID площадки") },
-                            singleLine = true
+                        if (state.venues.isNotEmpty()) {
+                            val selectedVenue = state.venues.firstOrNull { it.id == addVenueId }
+                            Box {
+                                OutlinedTextField(
+                                    value = selectedVenue?.label ?: "Выберите площадку",
+                                    onValueChange = {},
+                                    label = { Text("Площадка") },
+                                    readOnly = true,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                                TextButton(
+                                    onClick = { venueMenuExpanded = true },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) { Text(selectedVenue?.label ?: "Выберите площадку") }
+                                DropdownMenu(
+                                    expanded = venueMenuExpanded,
+                                    onDismissRequest = { venueMenuExpanded = false }
+                                ) {
+                                    state.venues.forEach { venue ->
+                                        DropdownMenuItem(
+                                            text = { Text(venue.label) },
+                                            onClick = { addVenueId = venue.id; venueMenuExpanded = false }
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            OutlinedTextField(
+                                value = addVenueId,
+                                onValueChange = { addVenueId = it },
+                                label = { Text("ID площадки") },
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+                    if (state.addError != null) {
+                        Text(
+                            text = when {
+                                state.addError!!.contains("ALREADY_MEMBER") -> "Пользователь уже состоит в организации"
+                                else -> state.addError!!
+                            },
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
                         )
                     }
                 }
             },
             confirmButton = {
-                Button(onClick = {
-                    vm.addMember(
-                        userId = addUserId.trim(),
-                        role = addRole,
-                        venueId = addVenueId.trim().ifBlank { null }
-                    )
-                    showAddDialog = false
-                    addUserId = ""
-                    addRole = "MANAGER"
-                    addVenueId = ""
-                }) { Text("Добавить") }
+                Button(
+                    onClick = {
+                        val phone = normalizePhone(addPhone.trim())
+                        vm.addMemberByPhone(
+                            phone = phone,
+                            role = addRole,
+                            venueId = addVenueId.ifBlank { null }
+                        )
+                        showAddDialog = false
+                        addPhone = ""; addRole = "MANAGER"; addVenueId = ""
+                    },
+                    enabled = addPhone.isNotBlank() && (addRole != "STAFF" || addVenueId.isNotBlank())
+                ) { Text("Добавить") }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) { Text("Отмена") }
+                TextButton(onClick = { showAddDialog = false; vm.clearAddError() }) { Text("Отмена") }
+            }
+        )
+    }
+
+    // Диалог подтверждения выхода — шаг 1
+    if (showLeaveConfirm1) {
+        AlertDialog(
+            onDismissRequest = { showLeaveConfirm1 = false },
+            title = { Text("Выйти из организации?") },
+            text = {
+                Text("Вы потеряете доступ к управлению мероприятиями и площадками организации.")
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showLeaveConfirm1 = false
+                        val isOwner = state.members.none { it.role != "OWNER" } // fallback — показываем второй шаг всегда для OWNER
+                        showLeaveConfirm2 = true
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Продолжить") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLeaveConfirm1 = false }) { Text("Отмена") }
+            }
+        )
+    }
+
+    // Диалог подтверждения выхода — шаг 2
+    if (showLeaveConfirm2) {
+        AlertDialog(
+            onDismissRequest = { showLeaveConfirm2 = false },
+            title = { Text("Подтвердите выход") },
+            text = {
+                Text(
+                    "Это действие нельзя отменить.\n\n" +
+                    "Если вы являетесь владельцем, убедитесь, что передали роль OWNER другому участнику."
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showLeaveConfirm2 = false
+                        vm.leaveOrganization()
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Выйти") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLeaveConfirm2 = false }) { Text("Отмена") }
             }
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.data.api.dto.VenueDto
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,8 +13,13 @@ import kotlinx.coroutines.launch
 
 data class OrgManagementState(
     val members: List<OrgMemberDto> = emptyList(),
+    val venues: List<VenueDto> = emptyList(),
     val isLoading: Boolean = true,
-    val error: String? = null
+    val error: String? = null,
+    val addError: String? = null,
+    val accountCreated: Boolean = false,
+    val leaveError: String? = null,
+    val leftOrg: Boolean = false
 )
 
 class OrgManagementViewModel(
@@ -31,7 +37,9 @@ class OrgManagementViewModel(
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true, error = null)
             try {
-                _state.value = OrgManagementState(members = orgMemberService.listMembers())
+                val members = orgMemberService.listMembers()
+                val venues = try { orgMemberService.listMyVenues() } catch (_: Exception) { emptyList() }
+                _state.value = OrgManagementState(members = members, venues = venues, isLoading = false)
             } catch (e: Exception) {
                 CrashReporter.log(e)
                 _state.value = OrgManagementState(isLoading = false, error = e.message)
@@ -53,5 +61,40 @@ class OrgManagementViewModel(
                 .onFailure { CrashReporter.log(it) }
             loadMembers()
         }
+    }
+
+    fun addMemberByPhone(phone: String, role: String, venueId: String?) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(addError = null, accountCreated = false)
+            try {
+                val result = orgMemberService.addMemberByPhone(phone = phone, role = role, venueId = venueId)
+                _state.value = _state.value.copy(accountCreated = result.accountCreated)
+                loadMembers()
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(addError = e.message)
+            }
+        }
+    }
+
+    fun clearAddError() {
+        _state.value = _state.value.copy(addError = null, accountCreated = false)
+    }
+
+    fun leaveOrganization() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(leaveError = null)
+            try {
+                orgMemberService.leaveOrganization()
+                _state.value = _state.value.copy(leftOrg = true)
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(leaveError = e.message)
+            }
+        }
+    }
+
+    fun clearLeaveError() {
+        _state.value = _state.value.copy(leaveError = null)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -24,13 +26,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -47,10 +52,17 @@ import com.karrad.ticketsclient.di.AppContainer
 @Composable
 fun VenueAccessScreen() {
     val navigator = LocalNavigator.currentOrThrow
-    val vm = viewModel { VenueAccessViewModel(AppContainer.venueAccessGrantService) }
+    val vm = viewModel {
+        VenueAccessViewModel(
+            venueAccessGrantService = AppContainer.venueAccessGrantService,
+            orgMemberService = AppContainer.orgMemberService
+        )
+    }
     val state by vm.state.collectAsState()
 
     var selectedTab by remember { mutableIntStateOf(0) }
+    var showRequestDialog by remember { mutableStateOf(false) }
+    var requestVenueId by remember { mutableStateOf("") }
 
     Column(
         modifier = Modifier
@@ -69,8 +81,12 @@ fun VenueAccessScreen() {
             }
             Text(
                 "Аренда площадок",
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
             )
+            IconButton(onClick = { showRequestDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Подать заявку на аренду")
+            }
         }
 
         ScrollableTabRow(selectedTabIndex = selectedTab, edgePadding = 16.dp) {
@@ -78,6 +94,21 @@ fun VenueAccessScreen() {
                 text = { Text("Входящие (${state.incoming.size})") })
             Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
                 text = { Text("Исходящие (${state.outgoing.size})") })
+        }
+
+        if (state.requestError != null) {
+            Text(
+                text = when {
+                    state.requestError!!.contains("404") || state.requestError!!.contains("not found", ignoreCase = true) ->
+                        "Площадка не найдена"
+                    state.requestError!!.contains("409") || state.requestError!!.contains("already", ignoreCase = true) ->
+                        "Заявка уже существует"
+                    else -> state.requestError!!
+                },
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+            )
         }
 
         when {
@@ -119,6 +150,55 @@ fun VenueAccessScreen() {
                 }
             }
         }
+    }
+
+    if (showRequestDialog) {
+        AlertDialog(
+            onDismissRequest = { showRequestDialog = false; vm.clearRequestError(); requestVenueId = "" },
+            title = { Text("Запрос на аренду площадки") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = requestVenueId,
+                        onValueChange = { requestVenueId = it },
+                        label = { Text("ID площадки") },
+                        placeholder = { Text("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    if (state.requestError != null) {
+                        Text(
+                            text = when {
+                                state.requestError!!.contains("404") || state.requestError!!.contains("not found", ignoreCase = true) ->
+                                    "Площадка не найдена"
+                                state.requestError!!.contains("409") || state.requestError!!.contains("already", ignoreCase = true) ->
+                                    "Заявка уже существует"
+                                else -> state.requestError!!
+                            },
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        vm.requestAccess(requestVenueId.trim())
+                        showRequestDialog = false
+                        requestVenueId = ""
+                    },
+                    enabled = requestVenueId.isNotBlank()
+                ) { Text("Отправить") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showRequestDialog = false
+                    vm.clearRequestError()
+                    requestVenueId = ""
+                }) { Text("Отмена") }
+            }
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueAccessViewModel.kt
@@ -3,6 +3,7 @@ package com.karrad.ticketsclient.ui.screen.org
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantService
 import com.karrad.ticketsclient.data.api.dto.VenueAccessGrantDto
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,11 +15,13 @@ data class VenueAccessState(
     val incoming: List<VenueAccessGrantDto> = emptyList(),
     val outgoing: List<VenueAccessGrantDto> = emptyList(),
     val isLoading: Boolean = true,
-    val error: String? = null
+    val error: String? = null,
+    val requestError: String? = null
 )
 
 class VenueAccessViewModel(
-    private val venueAccessGrantService: VenueAccessGrantService
+    private val venueAccessGrantService: VenueAccessGrantService,
+    private val orgMemberService: OrgMemberService
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(VenueAccessState())
@@ -34,7 +37,8 @@ class VenueAccessViewModel(
             try {
                 _state.value = VenueAccessState(
                     incoming = venueAccessGrantService.getIncomingRequests(),
-                    outgoing = venueAccessGrantService.getOutgoingRequests()
+                    outgoing = venueAccessGrantService.getOutgoingRequests(),
+                    isLoading = false
                 )
             } catch (e: Exception) {
                 CrashReporter.log(e)
@@ -57,5 +61,24 @@ class VenueAccessViewModel(
                 .onFailure { CrashReporter.log(it) }
             load()
         }
+    }
+
+    fun requestAccess(venueId: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(requestError = null)
+            try {
+                val membership = orgMemberService.getMyMembership()
+                    ?: throw IllegalStateException("Вы не состоите в организации")
+                venueAccessGrantService.requestAccess(venueId, membership.organizationId)
+                load()
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(requestError = e.message)
+            }
+        }
+    }
+
+    fun clearRequestError() {
+        _state.value = _state.value.copy(requestError = null)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationScreen.kt
@@ -1,0 +1,255 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
+import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
+import com.karrad.ticketsclient.di.AppContainer
+
+@Composable
+fun VenueApplicationScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val vm = viewModel { VenueApplicationViewModel(AppContainer.venueApplicationService) }
+    val state by vm.state.collectAsState()
+
+    var showForm by remember { mutableStateOf(false) }
+    var name by remember { mutableStateOf("") }
+    var cityLabel by remember { mutableStateOf("") }
+    var subjectLabel by remember { mutableStateOf("") }
+    var address by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+
+    LaunchedEffect(state.submitSuccess) {
+        if (state.submitSuccess) {
+            showForm = false
+            name = ""; cityLabel = ""; subjectLabel = ""; address = ""; description = ""
+            vm.clearSubmitSuccess()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Заявки на площадки",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { showForm = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Подать заявку")
+            }
+        }
+
+        when {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
+            }
+            state.applications.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Заявок пока нет", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(state.applications) { app ->
+                    VenueApplicationCard(app)
+                }
+                item { Spacer(Modifier.height(96.dp)) }
+            }
+        }
+    }
+
+    if (showForm) {
+        AlertDialog(
+            onDismissRequest = { showForm = false },
+            title = { Text("Заявка на площадку") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        label = { Text("Название площадки *") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = cityLabel,
+                        onValueChange = { cityLabel = it },
+                        label = { Text("Город *") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = subjectLabel,
+                        onValueChange = { subjectLabel = it },
+                        label = { Text("Субъект РФ *") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = address,
+                        onValueChange = { address = it },
+                        label = { Text("Адрес *") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { description = it },
+                        label = { Text("Описание") },
+                        maxLines = 3,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    if (state.error != null) {
+                        Text(
+                            text = state.error!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                    Text(
+                        "* Документы, подтверждающие владение, можно будет добавить после создания заявки.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        vm.submit(
+                            CreateVenueApplicationRequest(
+                                name = name.trim(),
+                                cityLabel = cityLabel.trim(),
+                                subjectLabel = subjectLabel.trim(),
+                                address = address.trim(),
+                                description = description.trim().ifBlank { null }
+                            )
+                        )
+                    },
+                    enabled = name.isNotBlank() && cityLabel.isNotBlank() && subjectLabel.isNotBlank() && address.isNotBlank() && !state.isSubmitting
+                ) {
+                    Text(if (state.isSubmitting) "Отправка..." else "Отправить")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showForm = false }) { Text("Отмена") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun VenueApplicationCard(app: VenueApplicationDto) {
+    val statusColor = when (app.status) {
+        "APPROVED" -> MaterialTheme.colorScheme.primary
+        "REJECTED" -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.tertiary
+    }
+    val statusLabel = when (app.status) {
+        "APPROVED" -> "Одобрено"
+        "REJECTED" -> "Отклонено"
+        else -> "На рассмотрении"
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = app.name,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                text = statusLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = statusColor
+            )
+        }
+        Text(
+            text = "${app.cityLabel}, ${app.address}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = app.createdAt.take(10),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        if (app.documentUrls.isNotEmpty()) {
+            Text(
+                text = "Документов: ${app.documentUrls.size}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationViewModel.kt
@@ -1,0 +1,65 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.VenueApplicationService
+import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
+import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class VenueApplicationState(
+    val applications: List<VenueApplicationDto> = emptyList(),
+    val isLoading: Boolean = true,
+    val isSubmitting: Boolean = false,
+    val error: String? = null,
+    val submitSuccess: Boolean = false
+)
+
+class VenueApplicationViewModel(
+    private val venueApplicationService: VenueApplicationService
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(VenueApplicationState())
+    val state: StateFlow<VenueApplicationState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            try {
+                _state.value = VenueApplicationState(
+                    applications = venueApplicationService.listMine(),
+                    isLoading = false
+                )
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = VenueApplicationState(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun submit(request: CreateVenueApplicationRequest) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isSubmitting = true, error = null)
+            try {
+                venueApplicationService.submit(request)
+                _state.value = _state.value.copy(isSubmitting = false, submitSuccess = true)
+                load()
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(isSubmitting = false, error = e.message)
+            }
+        }
+    }
+
+    fun clearSubmitSuccess() {
+        _state.value = _state.value.copy(submitSuccess = false)
+    }
+}


### PR DESCRIPTION
## Summary

- **#134** `VenueApplicationScreen` — список заявок на площадки с цветовыми статусами + форма создания (name, city, subject, address, description)
- **#135** `VenueAccessScreen` — кнопка `+` для создания заявки на аренду; `requestAccess()` берёт `organizationId` из membership автоматически
- **#136** Телефон вместо UUID в диалогах добавления участников:
  - `normalizePhone()` применяется перед отправкой
  - Dropdown площадок для роли STAFF (из `/api/v1/my/organization/venues`)
  - Snackbar "Создан новый аккаунт" при `accountCreated=true`
  - Ошибка `ALREADY_MEMBER` с понятным текстом
- **#137** Кнопка "Выйти из организации" в `OrgManagementScreen`:
  - Двойное подтверждение AlertDialog
  - После выхода → `navigator.pop()`
  - Ошибка `SOLE_OWNER` отображается под кнопкой

## Backend dependency

Requires: karrad1201/ticketsbackend#269

Closes #134, #135, #136, #137