### PR TITLE
feat(#139): загрузка документов для заявок на площадки

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.android.kt
@@ -1,0 +1,35 @@
+package com.karrad.ticketsclient.ui.util
+
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.karrad.ticketsclient.data.api.FileBytes
+
+@Composable
+actual fun rememberFilePicker(onFiles: (List<FileBytes>) -> Unit): () -> Unit {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetMultipleContents()
+    ) { uris ->
+        val result = uris.mapNotNull { uri ->
+            try {
+                val name = context.contentResolver
+                    .query(uri, null, null, null, null)
+                    ?.use { cursor ->
+                        cursor.moveToFirst()
+                        cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                    } ?: uri.lastPathSegment ?: "file"
+                val mime = context.contentResolver.getType(uri) ?: "application/octet-stream"
+                val bytes = context.contentResolver.openInputStream(uri)
+                    ?.use { it.readBytes() } ?: return@mapNotNull null
+                FileBytes(name, bytes, mime)
+            } catch (_: Exception) {
+                null
+            }
+        }
+        onFiles(result)
+    }
+    return { launcher.launch("*/*") }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
@@ -8,6 +8,8 @@ import io.ktor.client.request.header
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
+expect fun currentTimeMs(): Long
+
 fun createHttpClient(tokenProvider: () -> String? = { null }): HttpClient {
     val client = HttpClient {
         install(ContentNegotiation) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FileBytes.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/FileBytes.kt
@@ -1,0 +1,3 @@
+package com.karrad.ticketsclient.data.api
+
+data class FileBytes(val name: String, val bytes: ByteArray, val mimeType: String)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationApiService.kt
@@ -7,8 +7,14 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import io.ktor.utils.io.core.buildPacket
+import io.ktor.utils.io.core.writeFully
 
 class VenueApplicationApiService(
     private val httpClient: HttpClient,
@@ -23,4 +29,22 @@ class VenueApplicationApiService(
 
     override suspend fun listMine(): List<VenueApplicationDto> =
         httpClient.get("$baseUrl/api/v1/my/organization/venue-applications").body()
+
+    override suspend fun uploadDocuments(applicationId: String, files: List<FileBytes>): VenueApplicationDto =
+        httpClient.post("$baseUrl/api/v1/my/organization/venue-applications/$applicationId/documents") {
+            setBody(MultiPartFormDataContent(formData {
+                files.forEach { f ->
+                    appendInput(
+                        key = "files",
+                        headers = Headers.build {
+                            append(HttpHeaders.ContentDisposition, "filename=\"${f.name}\"")
+                            append(HttpHeaders.ContentType, f.mimeType)
+                        },
+                        size = f.bytes.size.toLong()
+                    ) {
+                        buildPacket { writeFully(f.bytes) }
+                    }
+                }
+            }))
+        }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueApplicationService.kt
@@ -6,4 +6,5 @@ import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
 interface VenueApplicationService {
     suspend fun submit(request: CreateVenueApplicationRequest): VenueApplicationDto
     suspend fun listMine(): List<VenueApplicationDto>
+    suspend fun uploadDocuments(applicationId: String, files: List<FileBytes>): VenueApplicationDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -18,13 +19,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -45,6 +50,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
 import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.util.rememberFilePicker
 
 @Composable
 fun VenueApplicationScreen() {
@@ -59,6 +65,15 @@ fun VenueApplicationScreen() {
     var address by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
 
+    var uploadingAppId by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val pickFiles = rememberFilePicker { files ->
+        val appId = uploadingAppId ?: return@rememberFilePicker
+        if (files.isNotEmpty()) vm.uploadDocuments(appId, files)
+        uploadingAppId = null
+    }
+
     LaunchedEffect(state.submitSuccess) {
         if (state.submitSuccess) {
             showForm = false
@@ -67,55 +82,82 @@ fun VenueApplicationScreen() {
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
-    ) {
-        Row(
+    LaunchedEffect(state.uploadError) {
+        if (state.uploadError != null) {
+            snackbarHostState.showSnackbar("Ошибка загрузки: ${state.uploadError}")
+            vm.clearUploadError()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .statusBarsPadding()
         ) {
-            IconButton(onClick = { navigator.pop() }) {
-                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { navigator.pop() }) {
+                    Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+                }
+                Text(
+                    "Заявки на площадки",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { showForm = true }) {
+                    Icon(Icons.Outlined.Add, contentDescription = "Подать заявку")
+                }
             }
-            Text(
-                "Заявки на площадки",
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.weight(1f)
-            )
-            IconButton(onClick = { showForm = true }) {
-                Icon(Icons.Outlined.Add, contentDescription = "Подать заявку")
+
+            when {
+                state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
+                }
+                state.applications.isEmpty() -> Box(
+                    Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("Заявок пока нет", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                else -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .navigationBarsPadding(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    item { Spacer(Modifier.height(8.dp)) }
+                    items(state.applications) { app ->
+                        VenueApplicationCard(
+                            app = app,
+                            isUploading = state.isUploading && uploadingAppId == app.id,
+                            onAddDocuments = {
+                                uploadingAppId = app.id
+                                pickFiles()
+                            }
+                        )
+                    }
+                    item { Spacer(Modifier.height(96.dp)) }
+                }
             }
         }
 
-        when {
-            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Ошибка: ${state.error}", color = MaterialTheme.colorScheme.error)
-            }
-            state.applications.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Заявок пока нет", color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            else -> LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-                    .navigationBarsPadding(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                item { Spacer(Modifier.height(8.dp)) }
-                items(state.applications) { app ->
-                    VenueApplicationCard(app)
-                }
-                item { Spacer(Modifier.height(96.dp)) }
-            }
-        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp)
+        )
     }
 
     if (showForm) {
@@ -167,7 +209,7 @@ fun VenueApplicationScreen() {
                         )
                     }
                     Text(
-                        "* Документы, подтверждающие владение, можно будет добавить после создания заявки.",
+                        "Документы можно прикрепить после создания заявки.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -186,7 +228,9 @@ fun VenueApplicationScreen() {
                             )
                         )
                     },
-                    enabled = name.isNotBlank() && cityLabel.isNotBlank() && subjectLabel.isNotBlank() && address.isNotBlank() && !state.isSubmitting
+                    enabled = name.isNotBlank() && cityLabel.isNotBlank() &&
+                        subjectLabel.isNotBlank() && address.isNotBlank() &&
+                        !state.isSubmitting
                 ) {
                     Text(if (state.isSubmitting) "Отправка..." else "Отправить")
                 }
@@ -199,7 +243,11 @@ fun VenueApplicationScreen() {
 }
 
 @Composable
-private fun VenueApplicationCard(app: VenueApplicationDto) {
+private fun VenueApplicationCard(
+    app: VenueApplicationDto,
+    isUploading: Boolean,
+    onAddDocuments: () -> Unit
+) {
     val statusColor = when (app.status) {
         "APPROVED" -> MaterialTheme.colorScheme.primary
         "REJECTED" -> MaterialTheme.colorScheme.error
@@ -226,7 +274,8 @@ private fun VenueApplicationCard(app: VenueApplicationDto) {
         ) {
             Text(
                 text = app.name,
-                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                modifier = Modifier.weight(1f)
             )
             Text(
                 text = statusLabel,
@@ -250,6 +299,38 @@ private fun VenueApplicationCard(app: VenueApplicationDto) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        if (app.status == "PENDING") {
+            Spacer(Modifier.height(4.dp))
+            if (isUploading) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    Text(
+                        "Загрузка документов...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                OutlinedButton(
+                    onClick = onAddDocuments,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        Icons.Outlined.AttachFile,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text(
+                        if (app.documentUrls.isEmpty()) "Прикрепить документы"
+                        else "Добавить ещё документы",
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueApplicationViewModel.kt
@@ -3,6 +3,7 @@ package com.karrad.ticketsclient.ui.screen.org
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.FileBytes
 import com.karrad.ticketsclient.data.api.VenueApplicationService
 import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
 import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
@@ -15,7 +16,9 @@ data class VenueApplicationState(
     val applications: List<VenueApplicationDto> = emptyList(),
     val isLoading: Boolean = true,
     val isSubmitting: Boolean = false,
+    val isUploading: Boolean = false,
     val error: String? = null,
+    val uploadError: String? = null,
     val submitSuccess: Boolean = false
 )
 
@@ -59,7 +62,25 @@ class VenueApplicationViewModel(
         }
     }
 
+    fun uploadDocuments(applicationId: String, files: List<FileBytes>) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isUploading = true, uploadError = null)
+            try {
+                venueApplicationService.uploadDocuments(applicationId, files)
+                _state.value = _state.value.copy(isUploading = false)
+                load()
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(isUploading = false, uploadError = e.message)
+            }
+        }
+    }
+
     fun clearSubmitSuccess() {
         _state.value = _state.value.copy(submitSuccess = false)
+    }
+
+    fun clearUploadError() {
+        _state.value = _state.value.copy(uploadError = null)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.kt
@@ -1,0 +1,7 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.runtime.Composable
+import com.karrad.ticketsclient.data.api.FileBytes
+
+@Composable
+expect fun rememberFilePicker(onFiles: (List<FileBytes>) -> Unit): () -> Unit

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/FilePicker.ios.kt
@@ -1,0 +1,7 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.runtime.Composable
+import com.karrad.ticketsclient.data.api.FileBytes
+
+@Composable
+actual fun rememberFilePicker(onFiles: (List<FileBytes>) -> Unit): () -> Unit = { }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -11,6 +11,7 @@ import com.karrad.ticketsclient.data.api.FakeScannerService
 import com.karrad.ticketsclient.data.api.FakeOrgMemberService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.FakeVenueAccessGrantService
+import com.karrad.ticketsclient.data.api.FakeVenueApplicationService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
 
@@ -29,6 +30,7 @@ fun initContainer(baseUrl: String) {
         profileService = FakeProfileService(),
         favoriteService = FakeFavoriteService(),
         orgMemberService = FakeOrgMemberService(),
-        venueAccessGrantService = FakeVenueAccessGrantService()
+        venueAccessGrantService = FakeVenueAccessGrantService(),
+        venueApplicationService = FakeVenueApplicationService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueApplicationService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueApplicationService.kt
@@ -1,0 +1,52 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueApplicationRequest
+import com.karrad.ticketsclient.data.api.dto.VenueApplicationDto
+
+class FakeVenueApplicationService : VenueApplicationService {
+
+    private val applications = mutableListOf(
+        VenueApplicationDto(
+            id = "app-1",
+            organizationId = "org-1",
+            name = "Тестовая площадка",
+            cityLabel = "Москва",
+            subjectLabel = "Москва",
+            address = "ул. Тестовая, 1",
+            description = "Описание тестовой площадки",
+            documentUrls = emptyList(),
+            status = "PENDING",
+            createdAt = "2026-04-25T10:00:00Z",
+            venueId = null
+        )
+    )
+
+    override suspend fun submit(request: CreateVenueApplicationRequest): VenueApplicationDto {
+        val app = VenueApplicationDto(
+            id = "app-${applications.size + 1}",
+            organizationId = "org-1",
+            name = request.name,
+            cityLabel = request.cityLabel,
+            subjectLabel = request.subjectLabel,
+            address = request.address,
+            description = request.description,
+            documentUrls = emptyList(),
+            status = "PENDING",
+            createdAt = "2026-04-26T10:00:00Z",
+            venueId = null
+        )
+        applications.add(app)
+        return app
+    }
+
+    override suspend fun listMine(): List<VenueApplicationDto> = applications.toList()
+
+    override suspend fun uploadDocuments(applicationId: String, files: List<FileBytes>): VenueApplicationDto {
+        val index = applications.indexOfFirst { it.id == applicationId }
+        val updated = applications[index].copy(
+            documentUrls = applications[index].documentUrls + files.map { "fake://docs/${it.name}" }
+        )
+        applications[index] = updated
+        return updated
+    }
+}


### PR DESCRIPTION
## Summary
- `FileBytes(name, bytes, mimeType)` в `data.api` — платформо-независимый контейнер для файлов
- `expect/actual rememberFilePicker`: Android — `ActivityResultContracts.GetMultipleContents`, iOS — заглушка
- `VenueApplicationService.uploadDocuments()` — multipart POST через Ktor на `/api/v1/my/organization/venue-applications/{id}/documents`
- UI: кнопка «Прикрепить документы» на карточках со статусом PENDING, spinner во время загрузки, Snackbar при ошибке
- `FakeVenueApplicationService` добавлен в mock-модуль
- fix: восстановлен `expect fun currentTimeMs()` (actual-реализации существовали без expect)

## Test plan
- [ ] Создать заявку → появляется кнопка «Прикрепить документы»
- [ ] Нажать кнопку → открывается системный file picker (Android)
- [ ] Выбрать файлы → показывается spinner, после загрузки счётчик «Документов: N» обновляется
- [ ] При ошибке сети — Snackbar с текстом ошибки
- [ ] APPROVED/REJECTED карточки кнопки не показывают

🤖 Generated with [Claude Code](https://claude.com/claude-code)