### PR TITLE
feat(#142): iOS CrashReporter — NSLog вместо заглушки

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/crash/CrashReporter.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/crash/CrashReporter.ios.kt
@@ -1,6 +1,14 @@
 package com.karrad.ticketsclient.crash
 
+import platform.Foundation.NSLog
+
 actual object CrashReporter {
-    actual fun log(throwable: Throwable) = Unit
-    actual fun setUserId(userId: String) = Unit
+    actual fun log(throwable: Throwable) {
+        NSLog("CrashReporter: %s — %s", throwable::class.simpleName ?: "Throwable", throwable.message ?: "")
+        throwable.cause?.let { NSLog("CrashReporter caused by: %s — %s", it::class.simpleName ?: "Throwable", it.message ?: "") }
+    }
+
+    actual fun setUserId(userId: String) {
+        NSLog("CrashReporter: userId=%s", userId)
+    }
 }


### PR DESCRIPTION
## Изменения

`CrashReporter.ios.kt`: заглушка заменена на реальное логирование через `NSLog`.

- `log(throwable)` — выводит класс исключения, сообщение и причину в system console
- `setUserId(userId)` — логирует userId (пригодится при интеграции Crashlytics)

## Почему NSLog, а не Firebase Crashlytics?

Firebase Crashlytics на iOS требует CocoaPods/SPM интеграции и `GoogleService-Info.plist` — это отдельная задача выходящая за рамки KMP кода. NSLog даёт немедленную видимость ошибок в Xcode console без инфраструктурных изменений.

Closes #142