### PR TITLE
refactor(#143): разбить FeedScreen.kt (678 строк) на компоненты

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
@@ -1,0 +1,170 @@
+package com.karrad.ticketsclient.ui.screen.feed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.component.EventImage
+import com.karrad.ticketsclient.ui.util.formatPrice
+import kotlinx.coroutines.launch
+
+// cardWidth = null → заполняет пространство пейджера; иначе — фиксированная ширина
+@Composable
+internal fun EventCard(
+    event: EventDto,
+    cardWidth: Dp?,
+    imageHeight: Dp = 165.dp,
+    onClick: () -> Unit
+) {
+    val widthMod = if (cardWidth != null) Modifier.width(cardWidth) else Modifier.fillMaxWidth()
+    var isFav by remember { mutableStateOf(AppSession.isFavorite(event.id)) }
+    val scope = rememberCoroutineScope()
+
+    Column(modifier = widthMod.clickable { onClick() }) {
+        Box(
+            modifier = Modifier
+                .then(widthMod)
+                .height(imageHeight)
+                .clip(RoundedCornerShape(14.dp))
+        ) {
+            EventImage(imageUrl = event.imageUrl, seed = event.id, modifier = Modifier.fillMaxWidth().height(imageHeight))
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(8.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(Color.Black.copy(alpha = 0.45f))
+                    .padding(horizontal = 7.dp, vertical = 3.dp)
+            ) {
+                Text(
+                    text = event.ageRating ?: "0+",
+                    color = Color.White,
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold)
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.35f))
+                    .clickable {
+                        val newFav = !isFav
+                        isFav = newFav
+                        AppSession.toggleFavorite(event.id, newFav)
+                        scope.launch {
+                            runCatching {
+                                if (newFav) AppContainer.favoriteService.add(event.id)
+                                else AppContainer.favoriteService.remove(event.id)
+                            }.onFailure {
+                                CrashReporter.log(it)
+                                isFav = !newFav
+                                AppSession.toggleFavorite(event.id, !newFav)
+                            }
+                        }
+                    }
+            ) {
+                Icon(
+                    if (isFav) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                    contentDescription = if (isFav) "Убрать из избранного" else "В избранное",
+                    tint = if (isFav) Color(0xFFFF4D6D) else Color.White,
+                    modifier = Modifier.size(15.dp).align(Alignment.Center)
+                )
+                Text(
+                    "+",
+                    color = Color.White,
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 9.sp,
+                    modifier = Modifier.align(Alignment.TopEnd).padding(top = 3.dp, end = 3.dp)
+                )
+            }
+
+            event.minPrice?.let { price ->
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(8.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.72f))
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        "от ${price.formatPrice()} ₽",
+                        color = Color.White,
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 10.sp
+                        )
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = event.label,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp
+            ),
+            color = Color(0xFF1C1C1E),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            lineHeight = 15.sp
+        )
+        Text(
+            text = event.venueId.venueShort(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+internal fun String.venueShort(): String = when (this) {
+    "venue-bolshoi"  -> "Большой театр"
+    "venue-arena"    -> "Арена"
+    "venue-cinema"   -> "Кинотеатр Октябрь"
+    "venue-club"     -> "Известия Hall"
+    "venue-museum"   -> "Музей совр. искусства"
+    "venue-theater"  -> "Театр на Таганке"
+    else             -> this
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventImagePlaceholder.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventImagePlaceholder.kt
@@ -1,0 +1,24 @@
+package com.karrad.ticketsclient.ui.screen.feed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun EventImagePlaceholder(seed: String, modifier: Modifier = Modifier) {
+    val palettes = listOf(
+        listOf(Color(0xFF1A1A2E), Color(0xFF16213E)),
+        listOf(Color(0xFF0F3460), Color(0xFF533483)),
+        listOf(Color(0xFF2D6A4F), Color(0xFF1B4332)),
+        listOf(Color(0xFF6A0572), Color(0xFF3A0CA3)),
+        listOf(Color(0xFF7B2D00), Color(0xFF3E1200)),
+        listOf(Color(0xFF023E8A), Color(0xFF0077B6)),
+        listOf(Color(0xFF1D3557), Color(0xFF457B9D)),
+        listOf(Color(0xFF3D0000), Color(0xFF6B0000))
+    )
+    val palette = palettes[kotlin.math.abs(seed.hashCode()) % palettes.size]
+    Box(modifier = modifier.background(Brush.verticalGradient(palette)))
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedContent.kt
@@ -1,0 +1,241 @@
+package com.karrad.ticketsclient.ui.screen.feed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+internal fun FeedContent(
+    feed: DiscoveryFeedResponseDto,
+    selectedDay: Int,
+    onDaySelect: (Int) -> Unit,
+    onEventClick: (EventDto) -> Unit,
+    hasMore: Boolean = false,
+    onLoadMore: () -> Unit = {}
+) {
+    val listState = rememberLazyListState()
+    val reachedBottom by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            val total = listState.layoutInfo.totalItemsCount
+            lastVisible != null && total > 0 && lastVisible.index >= total - 2
+        }
+    }
+    LaunchedEffect(reachedBottom) {
+        if (reachedBottom && hasMore) onLoadMore()
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 96.dp)
+    ) {
+        stickyHeader {
+            DateStrip(selectedDay = selectedDay, onDaySelect = onDaySelect)
+        }
+
+        if (feed.forYou.isNotEmpty()) {
+            item {
+                SectionHeader("Для вас")
+                ForYouSection(events = feed.forYou, onEventClick = onEventClick)
+            }
+        }
+
+        feed.byCategory.forEach { entry ->
+            item {
+                SectionHeader(entry.category.label, hasMore = true)
+                HorizontalEventRow(events = entry.events, onEventClick = onEventClick)
+            }
+        }
+
+        if (hasMore) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun FilteredResultsList(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
+    if (events.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                "Ничего не найдено",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+            contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 96.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(events, key = { it.id }) { event ->
+                EventCard(event = event, cardWidth = null, onClick = { onEventClick(event) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun DateStrip(selectedDay: Int, onDaySelect: (Int) -> Unit) {
+    val tz = TimeZone.currentSystemDefault()
+    val today = Clock.System.now().toLocalDateTime(tz).date
+    val listState = rememberLazyListState()
+
+    LazyRow(
+        state = listState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(vertical = 10.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        items(14) { offset ->
+            val date = today.plus(offset, DateTimeUnit.DAY)
+            val isSelected = offset == selectedDay
+            Column(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onDaySelect(offset) }
+                    .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = date.dayOfMonth.toString(),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                    color = if (isSelected) Color.White else MaterialTheme.colorScheme.onBackground
+                )
+                Text(
+                    text = date.dayOfWeek.shortRu(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isSelected) Color.White.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun DayOfWeek.shortRu(): String = when (this) {
+    DayOfWeek.MONDAY    -> "ПН"
+    DayOfWeek.TUESDAY   -> "ВТ"
+    DayOfWeek.WEDNESDAY -> "СР"
+    DayOfWeek.THURSDAY  -> "ЧТ"
+    DayOfWeek.FRIDAY    -> "ПТ"
+    DayOfWeek.SATURDAY  -> "СБ"
+    DayOfWeek.SUNDAY    -> "ВС"
+}
+
+@Composable
+private fun SectionHeader(title: String, hasMore: Boolean = false) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+        if (hasMore) {
+            Text(">", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ForYouSection(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
+    val pagerState = rememberPagerState { events.size }
+    Column {
+        HorizontalPager(
+            state = pagerState,
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            pageSpacing = 12.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) { page ->
+            EventCard(event = events[page], cardWidth = null, imageHeight = 200.dp, onClick = { onEventClick(events[page]) })
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            repeat(events.size) { i ->
+                val active = pagerState.currentPage == i
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 3.dp)
+                        .size(if (active) 8.dp else 6.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (active) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                        )
+                )
+            }
+        }
+        androidx.compose.foundation.layout.Spacer(Modifier.size(4.dp))
+    }
+}
+
+@Composable
+private fun HorizontalEventRow(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier.padding(bottom = 4.dp)
+    ) {
+        items(events, key = { it.id }) { event ->
+            EventCard(event = event, cardWidth = 155.dp, imageHeight = 165.dp, onClick = { onEventClick(event) })
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedHeader.kt
@@ -1,0 +1,90 @@
+package com.karrad.ticketsclient.ui.screen.feed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.karrad.ticketsclient.AppSession
+
+@Composable
+internal fun FeedHeader(
+    onSearchClick: () -> Unit = {},
+    onFilterClick: () -> Unit = {},
+    onCityClick: () -> Unit = {},
+    hasActiveFilter: Boolean = false
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { onCityClick() }
+                .padding(horizontal = 4.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Outlined.LocationOn,
+                contentDescription = "Сменить город",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = AppSession.city,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold)
+            )
+        }
+        Spacer(Modifier.weight(1f))
+        IconButton(
+            onClick = onSearchClick,
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            Icon(Icons.Default.Search, contentDescription = "Поиск",
+                tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(18.dp))
+        }
+        Spacer(Modifier.width(20.dp))
+        IconButton(
+            onClick = onFilterClick,
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(
+                    if (hasActiveFilter) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.surfaceVariant
+                )
+        ) {
+            Icon(Icons.Outlined.FilterList, contentDescription = "Фильтры",
+                tint = if (hasActiveFilter) Color.White else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(18.dp))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -1,88 +1,47 @@
 package com.karrad.ticketsclient.ui.screen.feed
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material.icons.outlined.FilterList
-import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
-import com.karrad.ticketsclient.crash.CrashReporter
-import com.karrad.ticketsclient.data.api.dto.CategoryEventsEntryDto
-import com.karrad.ticketsclient.data.api.dto.DiscoveryFeedResponseDto
-import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
-import com.karrad.ticketsclient.ui.component.EventImage
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 import com.karrad.ticketsclient.ui.navigation.SearchScreen
 import com.karrad.ticketsclient.ui.screen.tickets.OfflineBanner
-import com.karrad.ticketsclient.ui.util.formatPrice
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
-// ─── Screen ────────────────────────────────────────────────────────────────────
-
 @Composable
 fun FeedScreen() {
-    // Берём родительский навигатор: EventDetailScreen должен открываться
-    // поверх TabNavigator (без нижней панели)
     val navigator = LocalNavigator.currentOrThrow
     val rootNavigator = navigator.parent ?: navigator
 
@@ -91,9 +50,8 @@ fun FeedScreen() {
     var showFilters by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
-    // #93 — filter state and filtered results
     var activeFilter by remember { mutableStateOf<FilterState?>(null) }
-    var filteredEvents by remember { mutableStateOf<List<EventDto>?>(null) }
+    var filteredEvents by remember { mutableStateOf<List<com.karrad.ticketsclient.data.api.dto.EventDto>?>(null) }
     var filterLoading by remember { mutableStateOf(false) }
 
     if (showFilters) {
@@ -109,12 +67,12 @@ fun FeedScreen() {
                 scope.launch {
                     val dateStr = when (filter.selectedDate) {
                         "Завтра" -> {
-                            val tz = kotlinx.datetime.TimeZone.currentSystemDefault()
+                            val tz = TimeZone.currentSystemDefault()
                             Clock.System.now().toLocalDateTime(tz).date
                                 .plus(1, DateTimeUnit.DAY).toString()
                         }
                         "Послезавтра" -> {
-                            val tz = kotlinx.datetime.TimeZone.currentSystemDefault()
+                            val tz = TimeZone.currentSystemDefault()
                             Clock.System.now().toLocalDateTime(tz).date
                                 .plus(2, DateTimeUnit.DAY).toString()
                         }
@@ -154,7 +112,6 @@ fun FeedScreen() {
             OfflineBanner("Нет подключения · афиша недоступна")
         }
 
-        // #93 — active filter banner
         if (activeFilter?.hasActiveFilters == true) {
             Row(
                 modifier = Modifier
@@ -183,7 +140,6 @@ fun FeedScreen() {
                 CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
         } else if (filteredEvents != null) {
-            // #93 — show filtered results
             FilteredResultsList(
                 events = filteredEvents!!,
                 onEventClick = { rootNavigator.push(EventDetailScreen(it.id)) }
@@ -195,10 +151,12 @@ fun FeedScreen() {
                 }
                 is FeedState.Error -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("Не удалось загрузить события",
+                        Text(
+                            "Не удалось загрузить события",
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        Spacer(Modifier.height(12.dp))
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        androidx.compose.foundation.layout.Spacer(Modifier.padding(6.dp))
                         Button(
                             onClick = { viewModel.load() },
                             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
@@ -219,460 +177,4 @@ fun FeedScreen() {
             }
         }
     }
-}
-
-// ─── Header ────────────────────────────────────────────────────────────────────
-
-@Composable
-private fun FeedHeader(
-    onSearchClick: () -> Unit = {},
-    onFilterClick: () -> Unit = {},
-    onCityClick: () -> Unit = {},
-    hasActiveFilter: Boolean = false
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Row(
-            modifier = Modifier
-                .clip(RoundedCornerShape(8.dp))
-                .clickable { onCityClick() }
-                .padding(horizontal = 4.dp, vertical = 2.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                Icons.Outlined.LocationOn,
-                contentDescription = "Сменить город",
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(18.dp)
-            )
-            Spacer(Modifier.width(4.dp))
-            Text(
-                text = AppSession.city,
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold)
-            )
-        }
-        Spacer(Modifier.weight(1f))
-        IconButton(
-            onClick = onSearchClick,
-            modifier = Modifier
-                .size(36.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-        ) {
-            Icon(Icons.Default.Search, contentDescription = "Поиск",
-                tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(18.dp))
-        }
-        Spacer(Modifier.width(20.dp))
-        Box {
-            IconButton(
-                onClick = onFilterClick,
-                modifier = Modifier
-                    .size(36.dp)
-                    .clip(CircleShape)
-                    .background(
-                        if (hasActiveFilter) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.surfaceVariant
-                    )
-            ) {
-                Icon(Icons.Outlined.FilterList, contentDescription = "Фильтры",
-                    tint = if (hasActiveFilter) Color.White else MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.size(18.dp))
-            }
-        }
-    }
-}
-
-// ─── Filtered results list (#93) ───────────────────────────────────────────────
-
-@Composable
-private fun FilteredResultsList(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
-    if (events.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                "Ничего не найдено",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    } else {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-            contentPadding = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 96.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            items(events, key = { it.id }) { event ->
-                EventCard(event = event, cardWidth = null, onClick = { onEventClick(event) })
-            }
-        }
-    }
-}
-
-// ─── Date strip ────────────────────────────────────────────────────────────────
-
-@Composable
-private fun DateStrip(selectedDay: Int, onDaySelect: (Int) -> Unit) {
-    val tz = TimeZone.currentSystemDefault()
-    val today = Clock.System.now().toLocalDateTime(tz).date
-    val listState = rememberLazyListState()
-
-    LazyRow(
-        state = listState,
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(vertical = 10.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        items(14) { offset ->
-            val date = today.plus(offset, DateTimeUnit.DAY)
-            val isSelected = offset == selectedDay
-            Column(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(12.dp))
-                    .clickable { onDaySelect(offset) }
-                    .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = date.dayOfMonth.toString(),
-                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
-                    color = if (isSelected) Color.White else MaterialTheme.colorScheme.onBackground
-                )
-                Text(
-                    text = date.dayOfWeek.shortRu(),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (isSelected) Color.White.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-    }
-}
-
-private fun DayOfWeek.shortRu(): String = when (this) {
-    DayOfWeek.MONDAY    -> "ПН"
-    DayOfWeek.TUESDAY   -> "ВТ"
-    DayOfWeek.WEDNESDAY -> "СР"
-    DayOfWeek.THURSDAY  -> "ЧТ"
-    DayOfWeek.FRIDAY    -> "ПТ"
-    DayOfWeek.SATURDAY  -> "СБ"
-    DayOfWeek.SUNDAY    -> "ВС"
-}
-
-// ─── Feed content ──────────────────────────────────────────────────────────────
-
-@Composable
-private fun FeedContent(
-    feed: DiscoveryFeedResponseDto,
-    selectedDay: Int,
-    onDaySelect: (Int) -> Unit,
-    onEventClick: (EventDto) -> Unit,
-    hasMore: Boolean = false,
-    onLoadMore: () -> Unit = {}
-) {
-    val listState = rememberLazyListState()
-
-    // #99 — detect bottom of list for infinite scroll
-    val reachedBottom by remember {
-        derivedStateOf {
-            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
-            val total = listState.layoutInfo.totalItemsCount
-            lastVisible != null && total > 0 && lastVisible.index >= total - 2
-        }
-    }
-    LaunchedEffect(reachedBottom) {
-        if (reachedBottom && hasMore) onLoadMore()
-    }
-
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-        contentPadding = PaddingValues(bottom = 96.dp) // место под плавающий нав-бар
-    ) {
-        stickyHeader {
-            DateStrip(selectedDay = selectedDay, onDaySelect = onDaySelect)
-        }
-
-        if (feed.forYou.isNotEmpty()) {
-            item {
-                SectionHeader("Для вас")
-                ForYouSection(events = feed.forYou, onEventClick = onEventClick)
-            }
-        }
-
-        feed.byCategory.forEach { entry ->
-            item {
-                SectionHeader(entry.category.label, hasMore = true)
-                HorizontalEventRow(events = entry.events, onEventClick = onEventClick)
-            }
-        }
-
-        if (hasMore) {
-            item {
-                Box(
-                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-        }
-    }
-}
-
-// ─── Section header ────────────────────────────────────────────────────────────
-
-@Composable
-private fun SectionHeader(title: String, hasMore: Boolean = false) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(title, style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
-        if (hasMore) {
-            Text(
-                ">",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-// ─── "Для вас" pager ───────────────────────────────────────────────────────────
-
-@Composable
-private fun ForYouSection(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
-    val pagerState = rememberPagerState { events.size }
-
-    Column {
-        HorizontalPager(
-            state = pagerState,
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            pageSpacing = 12.dp,
-            modifier = Modifier.fillMaxWidth()
-        ) { page ->
-            EventCard(
-                event = events[page],
-                cardWidth = null,   // fillMaxWidth в пейджере
-                imageHeight = 200.dp,
-                onClick = { onEventClick(events[page]) }
-            )
-        }
-
-        // Dot indicators
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            repeat(events.size) { i ->
-                val active = pagerState.currentPage == i
-                Box(
-                    modifier = Modifier
-                        .padding(horizontal = 3.dp)
-                        .size(if (active) 8.dp else 6.dp)
-                        .clip(CircleShape)
-                        .background(
-                            if (active) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-                        )
-                )
-            }
-        }
-        Spacer(Modifier.height(4.dp))
-    }
-}
-
-// ─── Event card (универсальная: "Для вас" + категории) ────────────────────────
-// cardWidth = null → заполняет пространство пейджера; иначе — фиксированная ширина
-
-@Composable
-private fun EventCard(
-    event: EventDto,
-    cardWidth: androidx.compose.ui.unit.Dp?,
-    imageHeight: androidx.compose.ui.unit.Dp = 165.dp,
-    onClick: () -> Unit
-) {
-    val widthMod = if (cardWidth != null) Modifier.width(cardWidth) else Modifier.fillMaxWidth()
-    var isFav by remember { mutableStateOf(AppSession.isFavorite(event.id)) }
-    val scope = rememberCoroutineScope()
-
-    Column(modifier = widthMod.clickable { onClick() }) {
-        // ── Фото ──────────────────────────────────────────────────────────────
-        Box(
-            modifier = Modifier
-                .then(widthMod)
-                .height(imageHeight)
-                .clip(RoundedCornerShape(14.dp))
-        ) {
-            EventImage(imageUrl = event.imageUrl, seed = event.id, modifier = Modifier.fillMaxSize())
-
-            // Age rating — top left (полупрозрачный тёмный)
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(8.dp)
-                    .clip(RoundedCornerShape(6.dp))
-                    .background(Color.Black.copy(alpha = 0.45f))
-                    .padding(horizontal = 7.dp, vertical = 3.dp)
-            ) {
-                Text(
-                    text = event.ageRating ?: "0+",
-                    color = Color.White,
-                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold)
-                )
-            }
-
-            // Favourite — top right (полупрозрачный)
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(8.dp)
-                    .size(28.dp)
-                    .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.35f))
-                    .clickable {
-                        val newFav = !isFav
-                        isFav = newFav
-                        AppSession.toggleFavorite(event.id, newFav)
-                        scope.launch {
-                            runCatching {
-                                if (newFav) AppContainer.favoriteService.add(event.id)
-                                else AppContainer.favoriteService.remove(event.id)
-                            }.onFailure {
-                                CrashReporter.log(it)
-                                // rollback on error
-                                isFav = !newFav
-                                AppSession.toggleFavorite(event.id, !newFav)
-                            }
-                        }
-                    }
-            ) {
-                Icon(
-                    if (isFav) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-                    contentDescription = if (isFav) "Убрать из избранного" else "В избранное",
-                    tint = if (isFav) Color(0xFFFF4D6D) else Color.White,
-                    modifier = Modifier
-                        .size(15.dp)
-                        .align(Alignment.Center)
-                )
-                // Плюсик в правом верхнем углу кнопки
-                Text(
-                    "+",
-                    color = Color.White,
-                    fontSize = 9.sp,
-                    fontWeight = FontWeight.Bold,
-                    lineHeight = 9.sp,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 3.dp, end = 3.dp)
-                )
-            }
-
-            // Price — bottom right (полупрозрачный оранжевый)
-            event.minPrice?.let { price ->
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(8.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.72f))
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                ) {
-                    Text(
-                        "от ${price.formatPrice()} ₽",
-                        color = Color.White,
-                        style = MaterialTheme.typography.labelSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 10.sp
-                        )
-                    )
-                }
-            }
-        }
-
-        // ── Текст под фото ────────────────────────────────────────────────────
-        Spacer(Modifier.height(6.dp))
-        Text(
-            text = event.label,
-            style = MaterialTheme.typography.bodySmall.copy(
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 12.sp
-            ),
-            color = Color(0xFF1C1C1E),
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            lineHeight = 15.sp
-        )
-        Text(
-            text = event.venueId.venueShort(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
-}
-
-// ─── Horizontal category row ───────────────────────────────────────────────────
-
-@Composable
-private fun HorizontalEventRow(events: List<EventDto>, onEventClick: (EventDto) -> Unit) {
-    LazyRow(
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        modifier = Modifier.padding(bottom = 4.dp)
-    ) {
-        items(events, key = { it.id }) { event ->
-            EventCard(
-                event = event,
-                cardWidth = 155.dp,
-                imageHeight = 165.dp,
-                onClick = { onEventClick(event) }
-            )
-        }
-    }
-}
-
-// ─── Image placeholder ─────────────────────────────────────────────────────────
-
-@Composable
-fun EventImagePlaceholder(seed: String, modifier: Modifier = Modifier) {
-    val palettes = listOf(
-        listOf(Color(0xFF1A1A2E), Color(0xFF16213E)),
-        listOf(Color(0xFF0F3460), Color(0xFF533483)),
-        listOf(Color(0xFF2D6A4F), Color(0xFF1B4332)),
-        listOf(Color(0xFF6A0572), Color(0xFF3A0CA3)),
-        listOf(Color(0xFF7B2D00), Color(0xFF3E1200)),
-        listOf(Color(0xFF023E8A), Color(0xFF0077B6)),
-        listOf(Color(0xFF1D3557), Color(0xFF457B9D)),
-        listOf(Color(0xFF3D0000), Color(0xFF6B0000))
-    )
-    val palette = palettes[kotlin.math.abs(seed.hashCode()) % palettes.size]
-    Box(modifier = modifier.background(Brush.verticalGradient(palette)))
-}
-
-// ─── Helpers ───────────────────────────────────────────────────────────────────
-
-private fun String.venueShort(): String = when (this) {
-    "venue-bolshoi"  -> "Большой театр"
-    "venue-arena"    -> "Арена"
-    "venue-cinema"   -> "Кинотеатр Октябрь"
-    "venue-club"     -> "Известия Hall"
-    "venue-museum"   -> "Музей совр. искусства"
-    "venue-theater"  -> "Театр на Таганке"
-    else             -> this
 }


### PR DESCRIPTION
## Изменения

`FeedScreen.kt` (678 строк) разбит на 4 файла + выделен `EventImagePlaceholder`:

| Файл | Строк | Содержимое |
|------|-------|------------|
| `FeedScreen.kt` | 180 | Корневой экран, координация состояний и навигации |
| `FeedHeader.kt` | 90 | Панель с городом, поиском, кнопкой фильтра |
| `EventCard.kt` | 170 | Карточка события: фото, рейтинг, цена, кнопка избранного |
| `FeedContent.kt` | 241 | DateStrip, ForYouSection, HorizontalEventRow, FilteredResultsList |
| `EventImagePlaceholder.kt` | 24 | Цветной градиентный placeholder для изображений |

Поведение не изменено — чистый рефакторинг без изменения логики.

Closes #143