### PR TITLE
feat(#149): нормализация телефона — любой формат ввода

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
@@ -118,8 +118,9 @@ fun LoginScreen() {
                     error = null
                     scope.launch {
                         try {
-                            AppContainer.authService.sendCode(phone)
-                            navigator.push(SmsCodeScreen(isRegistration = false, phone = phone))
+                            val normalized = normalizePhone(phone)
+                            AppContainer.authService.sendCode(normalized)
+                            navigator.push(SmsCodeScreen(isRegistration = false, phone = normalized))
                         } catch (e: Exception) {
                             CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
@@ -1,6 +1,10 @@
 package com.karrad.ticketsclient.ui.screen.auth
 
-/** Приводит номер к виду +7XXXXXXXXXX */
+/**
+ * Приводит номер телефона к формату +7XXXXXXXXXX.
+ * Принимает любые форматы: 89161234567, 8 (916) 123-45-67,
+ * +7-916-123-45-67, 7 916 123 45 67, 9161234567 и т.д.
+ */
 fun normalizePhone(raw: String): String {
     val digits = raw.filter { it.isDigit() }
     return when {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
@@ -91,8 +91,9 @@ fun RegisterScreen() {
                     error = null
                     scope.launch {
                         try {
-                            AppContainer.authService.sendCode(phone)
-                            navigator.push(SmsCodeScreen(isRegistration = true, phone = phone))
+                            val normalized = normalizePhone(phone)
+                            AppContainer.authService.sendCode(normalized)
+                            navigator.push(SmsCodeScreen(isRegistration = true, phone = normalized))
                         } catch (e: Exception) {
                             CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."


### PR DESCRIPTION
## Summary
- `normalizePhone()` теперь вызывается перед `sendCode()` на `LoginScreen` и `RegisterScreen`
- Принимает любые форматы: `89161234567`, `8 (916) 123-45-67`, `+7-916-123-45-67`, `9161234567` и т.д.
- Closes #149

## Test plan
- [ ] Ввести `89XXXXXXXXX` — должно успешно отправить код
- [ ] Ввести `8 (9XX) XXX-XX-XX` — должно работать
- [ ] Ввести `+7XXXXXXXXXX` — должно работать как раньше

🤖 Generated with [Claude Code](https://claude.com/claude-code)