### PR TITLE
fix: регистрация и вход — token→accessToken + нормализация телефона

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/AuthDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/AuthDto.kt
@@ -12,7 +12,7 @@ data class LoginRequest(val phone: String, val code: String)
 data class RegisterRequest(val phone: String, val code: String, val fullName: String)
 
 @Serializable
-data class AuthResponseDto(val token: String, val user: UserDto)
+data class AuthResponseDto(val accessToken: String, val refreshToken: String? = null, val user: UserDto)
 
 @Serializable
 data class UserDto(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
@@ -118,8 +118,9 @@ fun LoginScreen() {
                     error = null
                     scope.launch {
                         try {
-                            AppContainer.authService.sendCode(phone)
-                            navigator.push(SmsCodeScreen(isRegistration = false, phone = phone))
+                            val normalized = normalizePhone(phone)
+                            AppContainer.authService.sendCode(normalized)
+                            navigator.push(SmsCodeScreen(isRegistration = false, phone = normalized))
                         } catch (e: Exception) {
                             CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/NameInputScreen.kt
@@ -96,7 +96,7 @@ fun NameInputScreen(phone: String = "", code: String = "") {
                     try {
                         val response = AppContainer.authService.register(phone, code, name)
                         AppSession.login(
-                            token = response.token,
+                            token = response.accessToken,
                             userId = response.user.id,
                             phone = response.user.phone,
                             fullName = response.user.fullName,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
@@ -1,6 +1,10 @@
 package com.karrad.ticketsclient.ui.screen.auth
 
-/** Приводит номер к виду +7XXXXXXXXXX */
+/**
+ * Приводит номер телефона к формату +7XXXXXXXXXX.
+ * Принимает любые форматы: 89161234567, 8 (916) 123-45-67,
+ * +7-916-123-45-67, 7 916 123 45 67, 9161234567 и т.д.
+ */
 fun normalizePhone(raw: String): String {
     val digits = raw.filter { it.isDigit() }
     return when {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
@@ -91,8 +91,9 @@ fun RegisterScreen() {
                     error = null
                     scope.launch {
                         try {
-                            AppContainer.authService.sendCode(phone)
-                            navigator.push(SmsCodeScreen(isRegistration = true, phone = phone))
+                            val normalized = normalizePhone(phone)
+                            AppContainer.authService.sendCode(normalized)
+                            navigator.push(SmsCodeScreen(isRegistration = true, phone = normalized))
                         } catch (e: Exception) {
                             CrashReporter.log(e)
                             error = "Не удалось отправить код. Проверьте номер."

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/SmsCodeScreen.kt
@@ -118,7 +118,7 @@ fun SmsCodeScreen(isRegistration: Boolean = false, phone: String = "") {
                         } else {
                             val response = AppContainer.authService.login(phone, code)
                             AppSession.login(
-                                token = response.token,
+                                token = response.accessToken,
                                 userId = response.user.id,
                                 phone = response.user.phone,
                                 fullName = response.user.fullName,

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeAuthService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeAuthService.kt
@@ -19,7 +19,7 @@ class FakeAuthService : AuthService {
     override suspend fun login(phone: String, code: String): AuthResponseDto {
         if (code == "0000") error("Неверный код")
         return AuthResponseDto(
-            token = "fake-token-login",
+            accessToken = "fake-token-login",
             user = UserDto(
                 id = "fake-user-id",
                 phone = phone,
@@ -31,7 +31,7 @@ class FakeAuthService : AuthService {
     override suspend fun register(phone: String, code: String, fullName: String): AuthResponseDto {
         if (code == "0000") error("Неверный код")
         return AuthResponseDto(
-            token = "fake-token-register",
+            accessToken = "fake-token-register",
             user = UserDto(
                 id = "fake-user-id-new",
                 phone = phone,


### PR DESCRIPTION
## Summary
- **Главный баг**: `AuthResponseDto.token` не совпадало с `accessToken` из ответа бекенда — десериализация падала с исключением при каждом логине/регистрации
- Переименовано `token → accessToken`, добавлен `refreshToken`
- Нормализация телефона теперь применяется на `LoginScreen` и `RegisterScreen` (#149)

## Test plan
- [ ] Зарегистрироваться с номером `89XXXXXXXXX` — должно успешно сохранить токен
- [ ] Войти с кодом 1234 на тест-окружении — должно работать

🤖 Generated with [Claude Code](https://claude.com/claude-code)