### PR TITLE
fix(#152): краш при нажатии «Заявки на площадки»

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -125,3 +125,9 @@ object VenueAccessScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueAccessScreen()
 }
+
+// Venue applications (OWNER)
+object VenueApplicationScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueApplicationScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
@@ -145,10 +144,7 @@ fun OrgManagementScreen() {
                     }
                     item {
                         OutlinedButton(
-                            onClick = { navigator.push(object : Screen {
-                                @Composable
-                                override fun Content() = VenueApplicationScreen()
-                            }) },
+                            onClick = { navigator.push(com.karrad.ticketsclient.ui.navigation.VenueApplicationScreen) },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Icon(Icons.Outlined.Domain, contentDescription = null, modifier = Modifier.size(18.dp))


### PR DESCRIPTION
## Проблема
`navigator.push(object : Screen { ... })` — анонимный объект не переживает пересоздание Activity (поворот экрана, возврат из фона), что приводит к крашу.

## Решение
- Добавлен `object VenueApplicationScreen : Screen` в `AppScreen.kt`
- `OrgManagementScreen`: кнопка использует `navigator.push(VenueApplicationScreen)`
- Удалён лишний импорт `cafe.adriel.voyager.core.screen.Screen`

Closes #152