### PR TITLE
fix(#153): очистить orgMembership при выходе из организации

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -60,6 +60,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
+import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.screen.auth.normalizePhone
 
@@ -92,7 +93,10 @@ fun OrgManagementScreen() {
     }
 
     LaunchedEffect(state.leftOrg) {
-        if (state.leftOrg) navigator.pop()
+        if (state.leftOrg) {
+            AppSession.orgMembership = null
+            navigator.pop()
+        }
     }
 
     Box(Modifier.fillMaxSize()) {


### PR DESCRIPTION
## Проблема
После `leftOrg = true` вызывался `navigator.pop()`, но `AppSession.orgMembership` оставался заполненным. `ProfileScreen` читает его напрямую и продолжал показывать кнопки управления.

## Решение
Перед `navigator.pop()` добавлен `AppSession.orgMembership = null`.

Closes #153