### PR TITLE
feat(#154): валидация телефона перед отправкой кода

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
@@ -119,6 +119,11 @@ fun LoginScreen() {
                     error = null
                     scope.launch {
                         try {
+                            if (!isValidPhone(phone)) {
+                                error = "Введите корректный номер телефона"
+                                loading = false
+                                return@launch
+                            }
                             val normalized = normalizePhone(phone)
                             AppContainer.authService.sendCode(normalized)
                             navigator.push(SmsCodeScreen(isRegistration = false, phone = normalized))

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/PhoneUtils.kt
@@ -14,3 +14,9 @@ fun normalizePhone(raw: String): String {
         else -> raw.trim()
     }
 }
+
+fun isValidPhone(raw: String): Boolean {
+    val digits = raw.filter { it.isDigit() }
+    return digits.length == 10 ||
+        (digits.length == 11 && (digits.startsWith("7") || digits.startsWith("8")))
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/RegisterScreen.kt
@@ -92,6 +92,11 @@ fun RegisterScreen() {
                     error = null
                     scope.launch {
                         try {
+                            if (!isValidPhone(phone)) {
+                                error = "Введите корректный номер телефона"
+                                loading = false
+                                return@launch
+                            }
                             val normalized = normalizePhone(phone)
                             AppContainer.authService.sendCode(normalized)
                             navigator.push(SmsCodeScreen(isRegistration = true, phone = normalized))


### PR DESCRIPTION
## Что изменилось
- `PhoneUtils.kt`: добавлена `isValidPhone(raw)` — возвращает true если номер содержит 10 цифр или 11 цифр начинающихся с 7/8
- `LoginScreen` / `RegisterScreen`: перед `sendCode` проверяем `isValidPhone`, при ошибке — «Введите корректный номер телефона»

Closes #154