### PR TITLE
fix(#155): обновить текст экрана «нет мероприятий» в сканере

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/scanner/ScannerScreen.kt
@@ -165,7 +165,7 @@ private fun NoAccessContent() {
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                "Сканер доступен только для\nменеджеров организаций",
+                "Нет доступных мероприятий для сканирования",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = androidx.compose.ui.text.style.TextAlign.Center


### PR DESCRIPTION
## Что изменилось
`ScannerScreen.NoAccessContent`: убрана фраза «Сканер доступен только для менеджеров организаций».
Теперь: «Нет доступных мероприятий для сканирования» — универсально для OWNER, MANAGER и STAFF.

Бэкенд-часть фильтрации: karrad1201/ticketsbackend#292

Closes #155