### PR TITLE
feat(#156): создание мероприятий для OWNER и MANAGER

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -1,5 +1,6 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -7,6 +8,10 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 
 class EventApiService(
     private val httpClient: HttpClient,
@@ -36,4 +41,10 @@ class EventApiService(
 
     override suspend fun getSeatMap(eventId: String): SeatMapDto =
         httpClient.get("$baseUrl/api/v1/inventory/$eventId/seat-map").body()
+
+    override suspend fun createEvent(request: CreateEventRequest): EventDto =
+        httpClient.post("$baseUrl/api/v1/events") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -1,5 +1,6 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -15,4 +16,5 @@ interface EventService {
     ): List<EventDto>
     suspend fun getTicketTypes(eventId: String): List<TicketTypeDto>
     suspend fun getSeatMap(eventId: String): SeatMapDto
+    suspend fun createEvent(request: CreateEventRequest): EventDto
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
@@ -25,3 +25,14 @@ data class CreateVenueApplicationRequest(
     val address: String,
     val description: String? = null
 )
+
+@Serializable
+data class CreateEventRequest(
+    val label: String,
+    val description: String,
+    val venueId: String,
+    val categoryId: String,
+    val time: String,
+    val imageUrl: String? = null,
+    val ageRating: String? = null
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -131,3 +131,9 @@ object VenueApplicationScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueApplicationScreen()
 }
+
+// Create event (OWNER/MANAGER)
+object CreateEventScreen : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.CreateEventScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
@@ -1,0 +1,241 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.di.AppContainer
+
+@Composable
+fun CreateEventScreen() {
+    val navigator = LocalNavigator.currentOrThrow
+    val vm = viewModel {
+        CreateEventViewModel(
+            AppContainer.eventService,
+            AppContainer.orgMemberService,
+            AppContainer.geoService
+        )
+    }
+    val state by vm.state.collectAsState()
+
+    var label by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var selectedVenueId by remember { mutableStateOf("") }
+    var selectedVenueLabel by remember { mutableStateOf("Выберите площадку") }
+    var selectedCategoryId by remember { mutableStateOf("") }
+    var selectedCategoryLabel by remember { mutableStateOf("Выберите категорию") }
+    var dateText by remember { mutableStateOf("") }
+    var timeText by remember { mutableStateOf("") }
+    var venueMenuExpanded by remember { mutableStateOf(false) }
+    var categoryMenuExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.success) {
+        if (state.success) navigator.pop()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Новое мероприятие",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        when {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            else -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Spacer(Modifier.height(4.dp))
+
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text("Название") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Описание") },
+                    minLines = 3,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // Venue selector
+                Box {
+                    OutlinedButton(
+                        onClick = { venueMenuExpanded = true },
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(selectedVenueLabel, modifier = Modifier.weight(1f))
+                    }
+                    DropdownMenu(
+                        expanded = venueMenuExpanded,
+                        onDismissRequest = { venueMenuExpanded = false }
+                    ) {
+                        state.venues.forEach { venue ->
+                            DropdownMenuItem(
+                                text = { Text(venue.label) },
+                                onClick = {
+                                    selectedVenueId = venue.id
+                                    selectedVenueLabel = venue.label
+                                    venueMenuExpanded = false
+                                }
+                            )
+                        }
+                        if (state.venues.isEmpty()) {
+                            DropdownMenuItem(
+                                text = { Text("Нет доступных площадок", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                                onClick = { venueMenuExpanded = false }
+                            )
+                        }
+                    }
+                }
+
+                // Category selector
+                Box {
+                    OutlinedButton(
+                        onClick = { categoryMenuExpanded = true },
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(selectedCategoryLabel, modifier = Modifier.weight(1f))
+                    }
+                    DropdownMenu(
+                        expanded = categoryMenuExpanded,
+                        onDismissRequest = { categoryMenuExpanded = false }
+                    ) {
+                        state.categories.forEach { cat ->
+                            DropdownMenuItem(
+                                text = { Text(cat.label) },
+                                onClick = {
+                                    selectedCategoryId = cat.id
+                                    selectedCategoryLabel = cat.label
+                                    categoryMenuExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                // Date input
+                OutlinedTextField(
+                    value = dateText,
+                    onValueChange = { dateText = it },
+                    label = { Text("Дата") },
+                    placeholder = { Text("2025-12-31") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // Time input
+                OutlinedTextField(
+                    value = timeText,
+                    onValueChange = { timeText = it },
+                    label = { Text("Время (UTC)") },
+                    placeholder = { Text("18:00") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                if (state.error != null) {
+                    Text(
+                        "Ошибка: ${state.error}",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+
+                val canSubmit = label.isNotBlank() && description.isNotBlank() &&
+                    selectedVenueId.isNotBlank() && selectedCategoryId.isNotBlank() &&
+                    dateText.matches(Regex("\\d{4}-\\d{2}-\\d{2}")) &&
+                    timeText.matches(Regex("\\d{2}:\\d{2}")) &&
+                    !state.isSubmitting
+
+                Button(
+                    onClick = {
+                        val isoTime = "${dateText}T${timeText}:00Z"
+                        vm.submit(label, description, selectedVenueId, selectedCategoryId, isoTime)
+                    },
+                    enabled = canSubmit,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    if (state.isSubmitting) CircularProgressIndicator(
+                        modifier = Modifier.padding(end = 8.dp),
+                        strokeWidth = 2.dp
+                    )
+                    Text("Создать мероприятие")
+                }
+
+                Spacer(Modifier.height(16.dp))
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
@@ -1,0 +1,78 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.EventService
+import com.karrad.ticketsclient.data.api.OrgMemberService
+import com.karrad.ticketsclient.data.api.dto.CategoryDto
+import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
+import com.karrad.ticketsclient.data.api.dto.VenueDto
+import com.karrad.ticketsclient.data.api.GeoService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class CreateEventState(
+    val venues: List<VenueDto> = emptyList(),
+    val categories: List<CategoryDto> = emptyList(),
+    val isLoading: Boolean = true,
+    val isSubmitting: Boolean = false,
+    val error: String? = null,
+    val success: Boolean = false
+)
+
+class CreateEventViewModel(
+    private val eventService: EventService,
+    private val orgMemberService: OrgMemberService,
+    private val geoService: GeoService
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CreateEventState())
+    val state: StateFlow<CreateEventState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            try {
+                val venues = orgMemberService.listMyVenues()
+                val categories = geoService.getCategories()
+                _state.value = _state.value.copy(venues = venues, categories = categories, isLoading = false)
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun submit(
+        label: String,
+        description: String,
+        venueId: String,
+        categoryId: String,
+        isoTime: String
+    ) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isSubmitting = true, error = null)
+            try {
+                eventService.createEvent(
+                    CreateEventRequest(
+                        label = label,
+                        description = description,
+                        venueId = venueId,
+                        categoryId = categoryId,
+                        time = isoTime
+                    )
+                )
+                _state.value = _state.value.copy(isSubmitting = false, success = true)
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                _state.value = _state.value.copy(isSubmitting = false, error = e.message)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Domain
 import androidx.compose.material.icons.outlined.ExitToApp
@@ -145,6 +146,16 @@ fun OrgManagementScreen() {
                             canDelete = member.userId != AppSession.userId,
                             onDelete = { vm.deleteMember(member.id) }
                         )
+                    }
+                    item {
+                        OutlinedButton(
+                            onClick = { navigator.push(com.karrad.ticketsclient.ui.navigation.CreateEventScreen) },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(Icons.Outlined.DateRange, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text("Создать мероприятие")
+                        }
                     }
                     item {
                         OutlinedButton(

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -1,5 +1,6 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatItemDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
@@ -66,4 +67,15 @@ class FakeEventService : EventService {
         }
         return SeatMapDto(sections = listOf(SeatSectionDto(key = "main", label = "Партер", rows = rows)))
     }
+
+    override suspend fun createEvent(request: CreateEventRequest): EventDto =
+        EventDto(
+            id = "fake-${request.label.hashCode()}",
+            label = request.label,
+            description = request.description,
+            venueId = request.venueId,
+            categoryId = request.categoryId,
+            time = request.time,
+            imageUrl = request.imageUrl
+        )
 }


### PR DESCRIPTION
## Что добавлено

### API слой
- `CreateEventRequest` DTO (label, description, venueId, categoryId, time, imageUrl, ageRating)
- `EventService.createEvent()` + реализация `EventApiService` → `POST /api/v1/events`
- `FakeEventService`: stub для mock-сборки

### ViewModel
`CreateEventViewModel`: загружает список площадок (`listMyVenues`) и категорий (`getCategories`), при сабмите вызывает `createEvent`.

### UI
- `CreateEventScreen`: форма с полями название, описание, выбор площадки (dropdown), выбор категории (dropdown), дата (YYYY-MM-DD), время (HH:mm). Комбинирует в ISO-8601 перед отправкой.
- `OrgManagementScreen`: кнопка «Создать мероприятие» перед «Заявки на площадки»
- `AppScreen`: именованный `object CreateEventScreen : Screen` (без краша при Recreation)

Closes #156