### PR TITLE
fix: ApiClient — HttpResponseValidator DSL для Ktor 3.0

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/ApiClient.kt
@@ -23,7 +23,7 @@ fun createHttpClient(tokenProvider: () -> String? = { null }): HttpClient {
                 coerceInputValues = true
             })
         }
-        install(HttpResponseValidator) {
+        HttpResponseValidator {
             handleResponseExceptionWithRequest { exception, _ ->
                 val response = (exception as? io.ktor.client.plugins.ResponseException)?.response
                     ?: return@handleResponseExceptionWithRequest


### PR DESCRIPTION
## Проблема
В Ktor 3.0 `HttpResponseValidator` — DSL-функция (`fun HttpClientConfig.HttpResponseValidator()`), а не companion object плагина.
Вызов `install(HttpResponseValidator) { ... }` не компилируется: `Unresolved reference 'handleResponseExceptionWithRequest'`.

## Решение
```kotlin
// было
install(HttpResponseValidator) { handleResponseExceptionWithRequest { ... } }
// стало
HttpResponseValidator { handleResponseExceptionWithRequest { ... } }
```

Фиксит CI на master и всех открытых ветках.