### PR TITLE
fix(#158): venueId обязателен при добавлении MANAGER

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -232,7 +232,7 @@ fun OrgManagementScreen() {
                             }
                         }
                     }
-                    if (addRole == "STAFF") {
+                    if (addRole == "STAFF" || addRole == "MANAGER") {
                         if (state.venues.isNotEmpty()) {
                             val selectedVenue = state.venues.firstOrNull { it.id == addVenueId }
                             Box {
@@ -293,7 +293,7 @@ fun OrgManagementScreen() {
                         showAddDialog = false
                         addPhone = ""; addRole = "MANAGER"; addVenueId = ""
                     },
-                    enabled = addPhone.isNotBlank() && (addRole != "STAFF" || addVenueId.isNotBlank())
+                    enabled = addPhone.isNotBlank() && addVenueId.isNotBlank()
                 ) { Text("Добавить") }
             },
             dismissButton = {


### PR DESCRIPTION
## Что изменилось
`OrgManagementScreen` — диалог добавления участника:
- Venue-selector теперь отображается для ролей **MANAGER** и **STAFF** (ранее только STAFF)
- Кнопка «Добавить» заблокирована пока не выбрана площадка (для обеих ролей)

Бэкенд-валидация: karrad1201/ticketsbackend#294

Closes #158