### PR TITLE
fix(#174): автовыбор Элисты при открытии экрана выбора города

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/CitySelectionScreen.kt
@@ -49,7 +49,11 @@ fun CitySelectionScreen(onCitySelected: ((String) -> Unit)? = null) {
     var selectedCity by remember { mutableStateOf<CityDto?>(null) }
 
     LaunchedEffect(Unit) {
-        allCities = try { AppContainer.geoService.getCities() } catch (e: Exception) { CrashReporter.log(e); emptyList() }
+        val cities = try { AppContainer.geoService.getCities() } catch (e: Exception) { CrashReporter.log(e); emptyList() }
+        allCities = cities
+        if (selectedCity == null) {
+            selectedCity = cities.find { it.name.equals("Элиста", ignoreCase = true) }
+        }
     }
 
     val cities = remember(query, allCities) {


### PR DESCRIPTION
## Summary
- После загрузки списка городов автоматически выбирается «Элиста» (если найдена)
- Пользователь видит экран с уже выбранным городом и может сразу нажать «Продолжить»
- Поиск и ручной выбор другого города по-прежнему работают

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)