### PR TITLE
fix(#169): передавать все выбранные категории в поиске по афише

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -26,7 +26,8 @@ class EventApiService(
         city: String,
         page: Int,
         dateFrom: String?,
-        dateTo: String?
+        dateTo: String?,
+        categoryIds: List<String>
     ): List<EventDto> =
         httpClient.get("$baseUrl/api/v1/events/search") {
             parameter("q", query)
@@ -34,6 +35,7 @@ class EventApiService(
             parameter("page", page)
             if (dateFrom != null) parameter("dateFrom", dateFrom)
             if (dateTo != null) parameter("dateTo", dateTo)
+            categoryIds.forEach { parameter("categoryId", it) }
         }.body()
 
     override suspend fun getTicketTypes(eventId: String): List<TicketTypeDto> =

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -12,7 +12,8 @@ interface EventService {
         city: String,
         page: Int = 0,
         dateFrom: String? = null,
-        dateTo: String? = null
+        dateTo: String? = null,
+        categoryIds: List<String> = emptyList()
     ): List<EventDto>
     suspend fun getTicketTypes(eventId: String): List<TicketTypeDto>
     suspend fun getSeatMap(eventId: String): SeatMapDto

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -78,13 +78,17 @@ fun FeedScreen() {
                         }
                         else -> null
                     }
-                    val query = filter.categories.firstOrNull() ?: ""
+                    val allCategories = runCatching { AppContainer.geoService.getCategories() }.getOrNull().orEmpty()
+                    val categoryIds = filter.categories.mapNotNull { name ->
+                        allCategories.find { it.label.equals(name, ignoreCase = true) }?.id
+                    }
                     runCatching {
                         AppContainer.eventService.search(
-                            query = query,
+                            query = "",
                             city = AppSession.city,
                             dateFrom = dateStr,
-                            dateTo = dateStr
+                            dateTo = dateStr,
+                            categoryIds = categoryIds
                         )
                     }.onSuccess { results ->
                         filteredEvents = results

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -35,7 +35,8 @@ class FakeEventService : EventService {
         city: String,
         page: Int,
         dateFrom: String?,
-        dateTo: String?
+        dateTo: String?,
+        categoryIds: List<String>
     ): List<EventDto> =
         if (query.length < 2) emptyList()
         else allEvents.filter {


### PR DESCRIPTION
## Summary
- `EventService.search` / `EventApiService.search` принимают `categoryIds: List<String>` вместо одиночного `categoryId: String?`
- `FeedScreen` разрешает все выбранные имена категорий в ID через `geoService.getCategories()` и отправляет каждый отдельным параметром `categoryId`
- `FakeEventService` обновлён под новую сигнатуру

Closes #169

## Test plan
- [ ] Выбрать одну категорию в фильтрах → список содержит только события этой категории
- [ ] Выбрать несколько категорий → список содержит события всех выбранных категорий
- [ ] Не выбирать категории → фильтр не применяется, список не изменяется

🤖 Generated with [Claude Code](https://claude.com/claude-code)