### PR TITLE
fix(#173): показывать venueLabel площадки вместо venueId в EventDetailScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
@@ -22,6 +22,7 @@ data class EventDto(
     val label: String,
     val description: String,
     val venueId: String,
+    val venueLabel: String? = null,
     val categoryId: String,
     val time: String,
     val imageUrl: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -194,7 +194,7 @@ fun EventDetailScreen(eventId: String) {
                 // Теги: возраст + площадка
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     event.ageRating?.let { TagChip(text = it, outlined = true) }
-                    TagChip(text = event.venueId.venueShort(), filled = true)
+                    TagChip(text = event.venueLabel ?: event.venueId, filled = true)
                 }
 
                 Spacer(Modifier.height(12.dp))
@@ -261,7 +261,7 @@ fun EventDetailScreen(eventId: String) {
                         modifier = Modifier.size(16.dp).padding(top = 2.dp)
                     )
                     Text(
-                        text = event.venueId.venueFull(),
+                        text = event.venueLabel ?: event.venueId,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -405,22 +405,3 @@ private fun String.formatEventDateFull(): String? = runCatching {
         "${ldt.hour.toString().padStart(2,'0')}:${ldt.minute.toString().padStart(2,'0')}"
 }.getOrNull()
 
-private fun String.venueShort(): String = when (this) {
-    "venue-bolshoi"  -> "Большой театр"
-    "venue-arena"    -> "Арена"
-    "venue-cinema"   -> "Кинотеатр Октябрь"
-    "venue-club"     -> "Известия Hall"
-    "venue-museum"   -> "Музей совр. искусства"
-    "venue-theater"  -> "Театр на Таганке"
-    else             -> this
-}
-
-private fun String.venueFull(): String = when (this) {
-    "venue-bolshoi"  -> "Большой театр, ул. Петровка, 1"
-    "venue-arena"    -> "Спортивный комплекс Арена, Лужнецкая наб., 24"
-    "venue-cinema"   -> "Кинотеатр Октябрь, Новый Арбат, 24"
-    "venue-club"     -> "Известия Hall, Пушкинская площадь, 5"
-    "venue-museum"   -> "ГМИИ им. Пушкина, ул. Волхонка, 12"
-    "venue-theater"  -> "Театр на Таганке, Земляной вал, 76"
-    else             -> this
-}


### PR DESCRIPTION
## Summary
- Добавлено поле `venueLabel: String? = null` в `EventDto` — бэкенд возвращает название площадки
- В `EventDetailScreen` используется `venueLabel ?: venueId` вместо хардкоденного маппинга
- Удалены функции `venueShort()` и `venueFull()` с захардкоженными UUID → название

Closes #173
Closes #171

## Test plan
- [ ] Открыть карточку мероприятия — в теге и в секции «Место проведения» отображается название площадки из бэкенда
- [ ] Если `venueLabel` не вернулся (null) — отображается `venueId` как запасной вариант

🤖 Generated with [Claude Code](https://claude.com/claude-code)