### PR TITLE
fix(#177): удалить кнопку «Пропустить» в auth-потоке

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/LoginScreen.kt
@@ -61,20 +61,6 @@ fun LoginScreen() {
             .statusBarsPadding()
             .imePadding()
     ) {
-        // Пропустить — top right
-        TextButton(
-            onClick = { navigator.replaceAll(MainScreen) },
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(8.dp)
-        ) {
-            Text(
-                text = "Пропустить",
-                color = Color(0xFF8E8E93),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
-
         // Main form — center
         Column(
             modifier = Modifier


### PR DESCRIPTION
## Summary
- Удалена кнопка «Пропустить» с `LoginScreen` — она давала прямой переход в `MainScreen` минуя онбординг

Closes #177

## Test plan
- [ ] Открыть экран входа — кнопки «Пропустить» нет
- [ ] Без авторизации нельзя попасть в главное меню

🤖 Generated with [Claude Code](https://claude.com/claude-code)