### PR TITLE
fix(#167): генерировать QR-код билета динамически из qrToken

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.qrose)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketDto.kt
@@ -11,5 +11,6 @@ data class TicketDto(
     val price: Int,
     val usedAt: String? = null,
     val venueName: String? = null,
-    val eventTime: String? = null
+    val eventTime: String? = null,
+    val qrToken: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickets/TicketsScreen.kt
@@ -52,6 +52,9 @@ import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.TicketDto
 import com.karrad.ticketsclient.di.AppContainer
+import io.github.alexzhirkevich.qrose.options.QrBrush
+import io.github.alexzhirkevich.qrose.options.solid
+import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 
 @Composable
@@ -334,8 +337,10 @@ private fun TicketCard(ticket: TicketDto, isArchived: Boolean, onClick: () -> Un
                 }
 
                 var showQrFullscreen by remember { mutableStateOf(false) }
+                val qrContent = ticket.qrToken ?: ticket.id
 
                 QrCode(
+                    content = qrContent,
                     modifier = Modifier
                         .size(160.dp)
                         .clickable { showQrFullscreen = true }
@@ -351,7 +356,7 @@ private fun TicketCard(ticket: TicketDto, isArchived: Boolean, onClick: () -> Un
                 Spacer(Modifier.height(8.dp))
 
                 if (showQrFullscreen) {
-                    QrFullscreenDialog(onDismiss = { showQrFullscreen = false })
+                    QrFullscreenDialog(content = qrContent, onDismiss = { showQrFullscreen = false })
                 }
             }
         }
@@ -360,67 +365,32 @@ private fun TicketCard(ticket: TicketDto, isArchived: Boolean, onClick: () -> Un
 
 // ─── QR-код ────────────────────────────────────────────────────────────────────
 
-// QR-паттерн вынесен на уровень файла — один экземпляр для всех вызовов
-private val QR_PATTERN = listOf(
-    listOf(1,1,1,1,1,1,1,0,1,0,1,0,1,1,1,1,1,1,1),
-    listOf(1,0,0,0,0,0,1,0,0,1,0,1,1,0,0,0,0,0,1),
-    listOf(1,0,1,1,1,0,1,0,1,0,1,0,1,0,1,1,1,0,1),
-    listOf(1,0,1,1,1,0,1,0,0,1,1,0,1,0,1,1,1,0,1),
-    listOf(1,0,1,1,1,0,1,0,1,1,0,1,1,0,1,1,1,0,1),
-    listOf(1,0,0,0,0,0,1,0,0,0,1,0,1,0,0,0,0,0,1),
-    listOf(1,1,1,1,1,1,1,0,1,0,1,0,1,1,1,1,1,1,1),
-    listOf(0,0,0,0,0,0,0,0,1,1,0,1,0,0,0,0,0,0,0),
-    listOf(1,0,1,1,0,1,1,1,0,1,1,0,1,1,0,1,1,1,0),
-    listOf(0,1,0,0,1,0,0,0,1,0,0,1,0,0,1,0,0,0,1),
-    listOf(1,1,0,1,0,1,1,0,1,1,0,0,1,0,1,1,0,1,1),
-    listOf(0,0,0,0,0,0,0,0,1,0,1,1,0,1,1,0,1,0,0),
-    listOf(1,1,1,1,1,1,1,0,0,1,0,1,1,0,0,1,0,1,0),
-    listOf(1,0,0,0,0,0,1,0,1,0,1,0,0,1,1,0,1,0,1),
-    listOf(1,0,1,1,1,0,1,0,0,1,1,1,0,1,0,1,0,1,0),
-    listOf(1,0,1,1,1,0,1,0,1,0,0,0,1,0,1,0,1,0,1),
-    listOf(1,0,1,1,1,0,1,0,0,1,0,1,1,1,0,1,1,1,0),
-    listOf(1,0,0,0,0,0,1,0,1,1,1,0,0,0,1,0,0,0,1),
-    listOf(1,1,1,1,1,1,1,0,0,0,1,1,0,1,0,1,0,1,0),
-)
-
-/**
- * Отрисовка QR-кода.
- * Ячейка: [cellDp]dp, зазор [gapDp]dp.
- * Итоговый размер сетки: 19 * cellDp + 18 * gapDp.
- * При cellDp=6, gapDp=1 → 114 + 18 = 132dp — помещается в 136dp (160 - 2*12 padding).
- */
 @Composable
-private fun QrCode(modifier: Modifier = Modifier, cellDp: Float = 6f, gapDp: Float = 1f) {
-    // Белый фон с rounded corners — clip ДО background, чтобы скруглить именно фон
+private fun QrCode(content: String, modifier: Modifier = Modifier) {
+    val painter = rememberQrCodePainter(content) {
+        colors {
+            dark = QrBrush.solid(Color.Black)
+            light = QrBrush.solid(Color.White)
+        }
+    }
     Box(
         modifier = modifier
             .background(Color.White, RoundedCornerShape(12.dp))
             .padding(12.dp),
         contentAlignment = Alignment.Center
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(gapDp.dp)) {
-            QR_PATTERN.forEach { row ->
-                Row(horizontalArrangement = Arrangement.spacedBy(gapDp.dp)) {
-                    row.forEach { cell ->
-                        Box(
-                            Modifier
-                                .size(cellDp.dp)
-                                .background(
-                                    color = if (cell == 1) Color.Black else Color.White,
-                                    shape = RoundedCornerShape(1.dp)
-                                )
-                        )
-                    }
-                }
-            }
-        }
+        androidx.compose.foundation.Image(
+            painter = painter,
+            contentDescription = "QR-код билета",
+            modifier = Modifier.fillMaxSize()
+        )
     }
 }
 
 // ─── Fullscreen QR диалог ──────────────────────────────────────────────────────
 
 @Composable
-private fun QrFullscreenDialog(onDismiss: () -> Unit) {
+private fun QrFullscreenDialog(content: String, onDismiss: () -> Unit) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -433,13 +403,12 @@ private fun QrFullscreenDialog(onDismiss: () -> Unit) {
             contentAlignment = Alignment.Center
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                // QR увеличен: cellDp=14, gapDp=2 → 19*14 + 18*2 = 266+36 = 302dp + 32dp padding = 334dp
                 QrCode(
+                    content = content,
                     modifier = Modifier
+                        .size(300.dp)
                         .padding(16.dp)
-                        .clickable { /* не пропускать клик наружу */ },
-                    cellDp = 14f,
-                    gapDp = 2f
+                        .clickable { /* не пропускать клик наружу */ }
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ firebase-crashlytics-gradle = "3.0.3"
 androidx-security-crypto = "1.1.0-alpha06"
 camerax = "1.4.2"
 mlkit-barcode = "17.3.0"
+qrose = "1.0.1"
 kotlinx-datetime = "0.6.2"
 kotlinx-coroutines = "1.10.2"
 ktor = "3.0.3"
@@ -58,6 +59,7 @@ camerax-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "ca
 camerax-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
 camerax-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 mlkit-barcode = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkit-barcode" }
+qrose = { module = "io.github.alexzhirkevich:qrose", version.ref = "qrose" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx", version.ref = "firebase-crashlytics-ktx" }


### PR DESCRIPTION
## Summary
- Добавлено поле `qrToken: String? = null` в `TicketDto` — бэкенд возвращает подписанный токен
- Хардкоденный 19×19 статичный QR-паттерн (одинаковый для всех билетов) удалён
- Добавлена зависимость `io.github.alexzhirkevich:qrose:1.0.1` для генерации QR в Compose Multiplatform
- `QrCode` и `QrFullscreenDialog` принимают `content: String`; используют `qrToken ?: id` как содержимое QR

Closes #167

## Test plan
- [ ] Открыть экран «Мои билеты» — каждый билет показывает уникальный QR
- [ ] Нажать на QR — открывается fullscreen диалог с увеличенным кодом
- [ ] Проверить: два разных билета → два разных QR-кода

🤖 Generated with [Claude Code](https://claude.com/claude-code)