### PR TITLE
fix(#321): UX-правки клиента

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -16,7 +16,7 @@ object AppSession {
     var authToken: String? = null
     var userId: String? = null
 
-    var city: String by mutableStateOf("Москва")
+    var city: String by mutableStateOf("Элиста")
 
     // Profile — заполняется при входе/регистрации
     var userName: String = ""

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
@@ -24,6 +24,7 @@ data class EventDto(
     val venueId: String,
     val venueLabel: String? = null,
     val categoryId: String,
+    val categoryLabel: String? = null,
     val time: String,
     val imageUrl: String? = null,
     val minPrice: Int? = null,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/InterestsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/InterestsScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,11 +36,12 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 
 private data class Interest(val name: String, val emoji: String, val size: Dp)
 
-private val interests = listOf(
+private val fallbackInterests = listOf(
     Interest("Театр",    "🎭", 96.dp),
     Interest("Кино",     "🎬", 76.dp),
     Interest("Концерты", "🎵", 104.dp),
@@ -51,11 +54,41 @@ private val interests = listOf(
     Interest("Танцы",    "💃", 68.dp),
 )
 
+private val interestEmojiMap = mapOf(
+    "театр" to ("🎭" to 96.dp), "театры" to ("🎭" to 96.dp), "спектакли" to ("🎭" to 96.dp),
+    "кино" to ("🎬" to 76.dp), "кино и видео" to ("🎬" to 76.dp),
+    "концерты" to ("🎵" to 104.dp), "музыка" to ("🎵" to 88.dp),
+    "шоу" to ("✨" to 68.dp),
+    "еда" to ("🍜" to 64.dp), "кулинария" to ("🍜" to 64.dp),
+    "спорт" to ("⚽" to 80.dp),
+    "выставки" to ("🖼️" to 88.dp), "выставка" to ("🖼️" to 88.dp),
+    "стендап" to ("🎤" to 72.dp),
+    "детям" to ("🎠" to 76.dp), "дети" to ("🎠" to 76.dp),
+    "танцы" to ("💃" to 68.dp),
+    "вечеринки" to ("🎊" to 72.dp),
+    "фестивали" to ("🎪" to 88.dp),
+    "лекции" to ("📚" to 72.dp),
+    "ярмарки" to ("🛍️" to 68.dp),
+)
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun InterestsScreen() {
     val navigator = LocalNavigator.currentOrThrow
     val selected = remember { mutableStateListOf<String>() }
+    val (interests, setInterests) = remember { mutableStateOf(fallbackInterests) }
+
+    LaunchedEffect(Unit) {
+        val categories = runCatching { AppContainer.geoService.getCategories() }.getOrNull()
+        if (!categories.isNullOrEmpty()) {
+            val sizes = listOf(96.dp, 76.dp, 104.dp, 68.dp, 64.dp, 80.dp, 88.dp, 72.dp, 76.dp, 68.dp)
+            setInterests(categories.mapIndexed { i, cat ->
+                val (emoji, size) = interestEmojiMap[cat.label.lowercase()]
+                    ?: ("🎟️" to sizes.getOrElse(i) { 80.dp })
+                Interest(cat.label, emoji, size)
+            })
+        }
+    }
 
     Column(
         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -190,9 +190,10 @@ fun EventDetailScreen(eventId: String) {
             ) {
                 Spacer(Modifier.height(16.dp))
 
-                // Теги: возраст + площадка
+                // Теги: возраст + категория + площадка
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     event.ageRating?.let { TagChip(text = it, outlined = true) }
+                    event.categoryLabel?.let { TagChip(text = it, outlined = true) }
                     TagChip(text = event.venueLabel ?: event.venueId, filled = true)
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
@@ -150,7 +150,7 @@ internal fun EventCard(
             lineHeight = 15.sp
         )
         Text(
-            text = event.venueId.venueShort(),
+            text = event.venueLabel ?: event.venueId.venueShort(),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -33,6 +33,7 @@ import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 import com.karrad.ticketsclient.ui.navigation.SearchScreen
 import com.karrad.ticketsclient.ui.screen.tickets.OfflineBanner
+import com.karrad.ticketsclient.data.api.dto.CategoryDto
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
@@ -53,10 +54,17 @@ fun FeedScreen() {
     var activeFilter by remember { mutableStateOf<FilterState?>(null) }
     var filteredEvents by remember { mutableStateOf<List<com.karrad.ticketsclient.data.api.dto.EventDto>?>(null) }
     var filterLoading by remember { mutableStateOf(false) }
+    var filterCategories by remember { mutableStateOf<List<CategoryDto>>(emptyList()) }
 
     if (showFilters) {
+        if (filterCategories.isEmpty()) {
+            scope.launch {
+                filterCategories = runCatching { AppContainer.geoService.getCategories() }.getOrDefault(emptyList())
+            }
+        }
         FiltersBottomSheet(
             onDismiss = { showFilters = false },
+            categories = filterCategories,
             onApply = { filter ->
                 activeFilter = filter
                 if (!filter.hasActiveFilters) {
@@ -78,11 +86,8 @@ fun FeedScreen() {
                         }
                         else -> null
                     }
-                    val allCategories = runCatching {
-                        AppContainer.geoService.getCategories()
-                    }.getOrNull().orEmpty()
                     val categoryIds = filter.categories.mapNotNull { name ->
-                        allCategories.find { it.label.equals(name, ignoreCase = true) }?.id
+                        filterCategories.find { it.label.equals(name, ignoreCase = true) }?.id
                     }
                     runCatching {
                         AppContainer.eventService.search(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FiltersBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FiltersBottomSheet.kt
@@ -43,28 +43,31 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.karrad.ticketsclient.data.api.dto.CategoryDto
 
 // ─── Data ──────────────────────────────────────────────────────────────────────
 
 private data class CategoryTag(val name: String, val emoji: String)
 
-private val allCategories = listOf(
-    CategoryTag("Кино",       "🎬"),
-    CategoryTag("Театр",      "🎭"),
-    CategoryTag("Концерты",   "🎵"),
-    CategoryTag("Шоу",        "✨"),
-    CategoryTag("Вечеринки",  "🎊"),
-    CategoryTag("Спорт",      "⚽"),
-    CategoryTag("Выставки",   "🖼️"),
-    CategoryTag("Стендап",    "🎤"),
-    CategoryTag("Детям",      "🎠"),
-    CategoryTag("Фестивали",  "🎪"),
-    CategoryTag("Лекции",     "📚"),
-    CategoryTag("Танцы",      "💃"),
-    CategoryTag("Кулинария",  "🍜"),
-    CategoryTag("Спектакли",  "🎪"),
-    CategoryTag("Ярмарки",    "🛍️"),
+private val categoryEmojiMap = mapOf(
+    "кино" to "🎬", "кино и видео" to "🎬",
+    "театр" to "🎭", "театры" to "🎭", "спектакли" to "🎭",
+    "концерты" to "🎵", "музыка" to "🎵",
+    "шоу" to "✨",
+    "вечеринки" to "🎊", "вечеринка" to "🎊",
+    "спорт" to "⚽",
+    "выставки" to "🖼️", "выставка" to "🖼️",
+    "стендап" to "🎤",
+    "детям" to "🎠", "дети" to "🎠",
+    "фестивали" to "🎪", "фестиваль" to "🎪",
+    "лекции" to "📚", "лекция" to "📚",
+    "танцы" to "💃",
+    "кулинария" to "🍜", "еда" to "🍜",
+    "ярмарки" to "🛍️",
 )
+
+private fun CategoryDto.toTag() =
+    CategoryTag(name = label, emoji = categoryEmojiMap[label.lowercase()] ?: "🎟️")
 
 private val SHOW_COUNT = 5          // показываем первых N, остальные — "+X"
 private val ageOptions = listOf("0+", "6+", "12+", "18+")
@@ -88,7 +91,11 @@ data class FilterState(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FiltersBottomSheet(onDismiss: () -> Unit, onApply: (FilterState) -> Unit = {}) {
+fun FiltersBottomSheet(
+    onDismiss: () -> Unit,
+    onApply: (FilterState) -> Unit = {},
+    categories: List<CategoryDto> = emptyList()
+) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val selectedCategories = remember { mutableStateListOf<String>() }
@@ -136,7 +143,7 @@ fun FiltersBottomSheet(onDismiss: () -> Unit, onApply: (FilterState) -> Unit = {
             FilterSectionTitle("Категория")
             Spacer(Modifier.height(10.dp))
             CategoryChips(
-                categories = allCategories,
+                categories = categories.map { it.toTag() },
                 selected = selectedCategories,
                 showAll = showAllCategories,
                 visibleCount = SHOW_COUNT,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
@@ -95,7 +95,7 @@ fun AboutScreen() {
             Spacer(Modifier.height(16.dp))
 
             Text(
-                "Tickets",
+                "Visit Kalmykia",
                 style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
@@ -118,7 +118,7 @@ fun AboutScreen() {
                     .background(MaterialTheme.colorScheme.surface)
                     .padding(16.dp)
             ) {
-                Text("Tickets — удобный способ покупать билеты на лучшие мероприятия Элисты: " +
+                Text("Visit Kalmykia — удобный способ покупать билеты на лучшие мероприятия Калмыкии: " +
                     "театры, кино, концерты, выставки и спорт.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -153,7 +153,7 @@ fun AboutScreen() {
             Spacer(Modifier.height(24.dp))
 
             Text(
-                "© 2026 Tickets App",
+                "© 2026 Visit Kalmykia",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.outlineVariant,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -61,8 +61,6 @@ fun EditProfileScreen() {
 
     var nameValue by remember { mutableStateOf(TextFieldValue(AppSession.userName)) }
     val name = nameValue.text
-    var cityValue by remember { mutableStateOf(TextFieldValue(AppSession.city)) }
-    val city = cityValue.text
     var selectedInterests by remember { mutableStateOf(AppSession.userInterests.toSet()) }
     var saving by remember { mutableStateOf(false) }
     var saveError by remember { mutableStateOf<String?>(null) }
@@ -123,17 +121,6 @@ fun EditProfileScreen() {
                 shape = RoundedCornerShape(12.dp)
             )
 
-            Spacer(Modifier.height(16.dp))
-
-            FieldLabel("Город")
-            OutlinedTextField(
-                value = cityValue,
-                onValueChange = { cityValue = it },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp)
-            )
-
             Spacer(Modifier.height(24.dp))
 
             FieldLabel("Интересы")
@@ -189,7 +176,6 @@ fun EditProfileScreen() {
                             AppSession.userName = updated.fullName
                             AppSession.userInterests = updated.interests
                             AppSession.userAvatarUrl = updated.avatarUrl
-                            AppSession.city = city.trim().ifBlank { AppSession.city }
                             navigator.pop()
                         } catch (e: Exception) {
                             CrashReporter.log(e)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -197,7 +197,7 @@ private fun SearchResultRow(event: EventDto, onClick: () -> Unit) {
             )
             Spacer(Modifier.height(2.dp))
             Text(
-                text = event.venueId.venueShort(),
+                text = event.venueLabel ?: event.venueId.venueShort(),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
@@ -70,7 +70,7 @@ class AppSessionTest {
     }
 
     @Test
-    fun `city has default value Moskva`() {
-        assertEquals("Москва", AppSession.city)
+    fun `city has default value Elista`() {
+        assertEquals("Элиста", AppSession.city)
     }
 }


### PR DESCRIPTION
## Summary
- Дефолтный город `Москва` → `Элиста` (AppSession)
- `EventDto` добавлен `categoryLabel: String? = null`
- `EventCard` и `SearchScreen`: показывать `venueLabel` вместо UUID площадки
- `EventDetailScreen`: тег категории рядом с возрастом и площадкой
- `AboutScreen`: переименовать «Tickets» → «Visit Kalmykia», обновить описание и копирайт
- `EditProfileScreen`: убрать поле редактирования города (остаётся только на главной)
- `FiltersBottomSheet`: принимать `List<CategoryDto>` из API вместо хардкода; emoji-маппинг по label
- `FeedScreen`: предзагружать категории из API при открытии фильтров (убрали lazy-запрос из `onApply`)
- `InterestsScreen`: загружать категории из API через `LaunchedEffect`, fallback на хардкод при ошибке

## Test plan
- [ ] Главный экран по умолчанию показывает «Элиста»
- [ ] На карточках событий показывается название площадки, не UUID
- [ ] В деталях события видны тег категории и возрастное ограничение
- [ ] В «О приложении» — «Visit Kalmykia» везде
- [ ] В настройках профиля нет поля «Город»
- [ ] Фильтры показывают категории из API
- [ ] Экран интересов при регистрации загружает категории из API

🤖 Generated with [Claude Code](https://claude.com/claude-code)