### PR TITLE
feat(#318): экран управления залами площадки (VenueSpaces)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -16,7 +16,7 @@ object AppSession {
     var authToken: String? = null
     var userId: String? = null
 
-    var city: String by mutableStateOf("Москва")
+    var city: String by mutableStateOf("Элиста")
 
     // Profile — заполняется при входе/регистрации
     var userName: String = ""

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceApiService.kt
@@ -1,0 +1,26 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+
+class VenueSpaceApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : VenueSpaceService {
+
+    override suspend fun list(venueId: String): List<VenueSpaceDto> =
+        httpClient.get("$baseUrl/api/v1/venues/$venueId/spaces").body()
+
+    override suspend fun add(venueId: String, request: CreateVenueSpaceRequest): VenueSpaceDto =
+        httpClient.post("$baseUrl/api/v1/venues/$venueId/spaces") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceService.kt
@@ -1,0 +1,9 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
+
+interface VenueSpaceService {
+    suspend fun list(venueId: String): List<VenueSpaceDto>
+    suspend fun add(venueId: String, request: CreateVenueSpaceRequest): VenueSpaceDto
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
@@ -24,6 +24,7 @@ data class EventDto(
     val venueId: String,
     val venueLabel: String? = null,
     val categoryId: String,
+    val categoryLabel: String? = null,
     val time: String,
     val imageUrl: String? = null,
     val minPrice: Int? = null,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueSpaceDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueSpaceDto.kt
@@ -1,0 +1,18 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VenueSpaceDto(
+    val id: String,
+    val label: String,
+    val type: String = "ADMISSION",
+    val capacity: Int = 0
+)
+
+@Serializable
+data class CreateVenueSpaceRequest(
+    val label: String,
+    val type: String,
+    val capacity: Int
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -24,6 +24,8 @@ import com.karrad.ticketsclient.data.api.VenueAccessGrantApiService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantService
 import com.karrad.ticketsclient.data.api.VenueApplicationApiService
 import com.karrad.ticketsclient.data.api.VenueApplicationService
+import com.karrad.ticketsclient.data.api.VenueSpaceApiService
+import com.karrad.ticketsclient.data.api.VenueSpaceService
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.data.api.createHttpClient
 
@@ -75,6 +77,9 @@ object AppContainer {
     lateinit var venueApplicationService: VenueApplicationService
         private set
 
+    lateinit var venueSpaceService: VenueSpaceService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
@@ -93,7 +98,8 @@ object AppContainer {
         favoriteService: FavoriteService,
         orgMemberService: OrgMemberService,
         venueAccessGrantService: VenueAccessGrantService,
-        venueApplicationService: VenueApplicationService
+        venueApplicationService: VenueApplicationService,
+        venueSpaceService: VenueSpaceService
     ) {
         this.isMock = isMock
         this.baseUrl = baseUrl
@@ -110,6 +116,7 @@ object AppContainer {
         this.orgMemberService = orgMemberService
         this.venueAccessGrantService = venueAccessGrantService
         this.venueApplicationService = venueApplicationService
+        this.venueSpaceService = venueSpaceService
     }
 }
 
@@ -130,6 +137,7 @@ fun AppContainer.initReal(baseUrl: String) {
         favoriteService = FavoriteApiService(client, baseUrl),
         orgMemberService = OrgMemberApiService(client, baseUrl),
         venueAccessGrantService = VenueAccessGrantApiService(client, baseUrl),
-        venueApplicationService = VenueApplicationApiService(client, baseUrl)
+        venueApplicationService = VenueApplicationApiService(client, baseUrl),
+        venueSpaceService = VenueSpaceApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -137,3 +137,9 @@ object CreateEventScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.CreateEventScreen()
 }
+
+// Venue spaces management (OWNER)
+data class VenueSpacesScreen(val venueId: String, val venueLabel: String) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueSpacesScreen(venueId, venueLabel)
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/InterestsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/auth/InterestsScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,11 +36,12 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 
 private data class Interest(val name: String, val emoji: String, val size: Dp)
 
-private val interests = listOf(
+private val fallbackInterests = listOf(
     Interest("Театр",    "🎭", 96.dp),
     Interest("Кино",     "🎬", 76.dp),
     Interest("Концерты", "🎵", 104.dp),
@@ -51,11 +54,41 @@ private val interests = listOf(
     Interest("Танцы",    "💃", 68.dp),
 )
 
+private val interestEmojiMap = mapOf(
+    "театр" to ("🎭" to 96.dp), "театры" to ("🎭" to 96.dp), "спектакли" to ("🎭" to 96.dp),
+    "кино" to ("🎬" to 76.dp), "кино и видео" to ("🎬" to 76.dp),
+    "концерты" to ("🎵" to 104.dp), "музыка" to ("🎵" to 88.dp),
+    "шоу" to ("✨" to 68.dp),
+    "еда" to ("🍜" to 64.dp), "кулинария" to ("🍜" to 64.dp),
+    "спорт" to ("⚽" to 80.dp),
+    "выставки" to ("🖼️" to 88.dp), "выставка" to ("🖼️" to 88.dp),
+    "стендап" to ("🎤" to 72.dp),
+    "детям" to ("🎠" to 76.dp), "дети" to ("🎠" to 76.dp),
+    "танцы" to ("💃" to 68.dp),
+    "вечеринки" to ("🎊" to 72.dp),
+    "фестивали" to ("🎪" to 88.dp),
+    "лекции" to ("📚" to 72.dp),
+    "ярмарки" to ("🛍️" to 68.dp),
+)
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun InterestsScreen() {
     val navigator = LocalNavigator.currentOrThrow
     val selected = remember { mutableStateListOf<String>() }
+    val (interests, setInterests) = remember { mutableStateOf(fallbackInterests) }
+
+    LaunchedEffect(Unit) {
+        val categories = runCatching { AppContainer.geoService.getCategories() }.getOrNull()
+        if (!categories.isNullOrEmpty()) {
+            val sizes = listOf(96.dp, 76.dp, 104.dp, 68.dp, 64.dp, 80.dp, 88.dp, 72.dp, 76.dp, 68.dp)
+            setInterests(categories.mapIndexed { i, cat ->
+                val (emoji, size) = interestEmojiMap[cat.label.lowercase()]
+                    ?: ("🎟️" to sizes.getOrElse(i) { 80.dp })
+                Interest(cat.label, emoji, size)
+            })
+        }
+    }
 
     Column(
         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -190,9 +190,10 @@ fun EventDetailScreen(eventId: String) {
             ) {
                 Spacer(Modifier.height(16.dp))
 
-                // Теги: возраст + площадка
+                // Теги: возраст + категория + площадка
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     event.ageRating?.let { TagChip(text = it, outlined = true) }
+                    event.categoryLabel?.let { TagChip(text = it, outlined = true) }
                     TagChip(text = event.venueLabel ?: event.venueId, filled = true)
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
@@ -150,7 +150,7 @@ internal fun EventCard(
             lineHeight = 15.sp
         )
         Text(
-            text = event.venueId.venueShort(),
+            text = event.venueLabel ?: event.venueId.venueShort(),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -33,6 +33,7 @@ import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 import com.karrad.ticketsclient.ui.navigation.SearchScreen
 import com.karrad.ticketsclient.ui.screen.tickets.OfflineBanner
+import com.karrad.ticketsclient.data.api.dto.CategoryDto
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
@@ -53,10 +54,17 @@ fun FeedScreen() {
     var activeFilter by remember { mutableStateOf<FilterState?>(null) }
     var filteredEvents by remember { mutableStateOf<List<com.karrad.ticketsclient.data.api.dto.EventDto>?>(null) }
     var filterLoading by remember { mutableStateOf(false) }
+    var filterCategories by remember { mutableStateOf<List<CategoryDto>>(emptyList()) }
 
     if (showFilters) {
+        if (filterCategories.isEmpty()) {
+            scope.launch {
+                filterCategories = runCatching { AppContainer.geoService.getCategories() }.getOrDefault(emptyList())
+            }
+        }
         FiltersBottomSheet(
             onDismiss = { showFilters = false },
+            categories = filterCategories,
             onApply = { filter ->
                 activeFilter = filter
                 if (!filter.hasActiveFilters) {
@@ -78,11 +86,8 @@ fun FeedScreen() {
                         }
                         else -> null
                     }
-                    val allCategories = runCatching {
-                        AppContainer.geoService.getCategories()
-                    }.getOrNull().orEmpty()
                     val categoryIds = filter.categories.mapNotNull { name ->
-                        allCategories.find { it.label.equals(name, ignoreCase = true) }?.id
+                        filterCategories.find { it.label.equals(name, ignoreCase = true) }?.id
                     }
                     runCatching {
                         AppContainer.eventService.search(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FiltersBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FiltersBottomSheet.kt
@@ -43,28 +43,31 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.karrad.ticketsclient.data.api.dto.CategoryDto
 
 // ─── Data ──────────────────────────────────────────────────────────────────────
 
 private data class CategoryTag(val name: String, val emoji: String)
 
-private val allCategories = listOf(
-    CategoryTag("Кино",       "🎬"),
-    CategoryTag("Театр",      "🎭"),
-    CategoryTag("Концерты",   "🎵"),
-    CategoryTag("Шоу",        "✨"),
-    CategoryTag("Вечеринки",  "🎊"),
-    CategoryTag("Спорт",      "⚽"),
-    CategoryTag("Выставки",   "🖼️"),
-    CategoryTag("Стендап",    "🎤"),
-    CategoryTag("Детям",      "🎠"),
-    CategoryTag("Фестивали",  "🎪"),
-    CategoryTag("Лекции",     "📚"),
-    CategoryTag("Танцы",      "💃"),
-    CategoryTag("Кулинария",  "🍜"),
-    CategoryTag("Спектакли",  "🎪"),
-    CategoryTag("Ярмарки",    "🛍️"),
+private val categoryEmojiMap = mapOf(
+    "кино" to "🎬", "кино и видео" to "🎬",
+    "театр" to "🎭", "театры" to "🎭", "спектакли" to "🎭",
+    "концерты" to "🎵", "музыка" to "🎵",
+    "шоу" to "✨",
+    "вечеринки" to "🎊", "вечеринка" to "🎊",
+    "спорт" to "⚽",
+    "выставки" to "🖼️", "выставка" to "🖼️",
+    "стендап" to "🎤",
+    "детям" to "🎠", "дети" to "🎠",
+    "фестивали" to "🎪", "фестиваль" to "🎪",
+    "лекции" to "📚", "лекция" to "📚",
+    "танцы" to "💃",
+    "кулинария" to "🍜", "еда" to "🍜",
+    "ярмарки" to "🛍️",
 )
+
+private fun CategoryDto.toTag() =
+    CategoryTag(name = label, emoji = categoryEmojiMap[label.lowercase()] ?: "🎟️")
 
 private val SHOW_COUNT = 5          // показываем первых N, остальные — "+X"
 private val ageOptions = listOf("0+", "6+", "12+", "18+")
@@ -88,7 +91,11 @@ data class FilterState(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FiltersBottomSheet(onDismiss: () -> Unit, onApply: (FilterState) -> Unit = {}) {
+fun FiltersBottomSheet(
+    onDismiss: () -> Unit,
+    onApply: (FilterState) -> Unit = {},
+    categories: List<CategoryDto> = emptyList()
+) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val selectedCategories = remember { mutableStateListOf<String>() }
@@ -136,7 +143,7 @@ fun FiltersBottomSheet(onDismiss: () -> Unit, onApply: (FilterState) -> Unit = {
             FilterSectionTitle("Категория")
             Spacer(Modifier.height(10.dp))
             CategoryChips(
-                categories = allCategories,
+                categories = categories.map { it.toTag() },
                 selected = selectedCategories,
                 showAll = showAllCategories,
                 visibleCount = SHOW_COUNT,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -62,6 +62,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.navigation.VenueSpacesScreen
 import com.karrad.ticketsclient.ui.screen.auth.normalizePhone
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -146,6 +147,48 @@ fun OrgManagementScreen() {
                             canDelete = member.userId != AppSession.userId,
                             onDelete = { vm.deleteMember(member.id) }
                         )
+                    }
+                    if (state.venues.isNotEmpty()) {
+                        item {
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                "Площадки",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 4.dp)
+                            )
+                        }
+                        items(state.venues) { venue ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .background(MaterialTheme.colorScheme.surface)
+                                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Domain,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Spacer(Modifier.width(10.dp))
+                                Text(
+                                    venue.label,
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                    modifier = Modifier.weight(1f)
+                                )
+                                OutlinedButton(
+                                    onClick = { navigator.push(VenueSpacesScreen(venue.id, venue.label)) },
+                                    modifier = Modifier.height(32.dp),
+                                    contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp)
+                                ) {
+                                    Text("Залы", style = MaterialTheme.typography.labelMedium)
+                                }
+                            }
+                        }
+                        item { Spacer(Modifier.height(4.dp)) }
                     }
                     item {
                         OutlinedButton(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
@@ -1,0 +1,259 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun VenueSpacesScreen(venueId: String, venueLabel: String) {
+    val scope = rememberCoroutineScope()
+    val spaces = remember { mutableStateListOf<VenueSpaceDto>() }
+    var loading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(venueId) {
+        loading = true
+        runCatching { AppContainer.venueSpaceService.list(venueId) }
+            .onSuccess { spaces.addAll(it) }
+            .onFailure { error = it.message }
+        loading = false
+    }
+
+    if (showAddDialog) {
+        AddVenueSpaceDialog(
+            onDismiss = { showAddDialog = false },
+            onConfirm = { label, type, capacity ->
+                showAddDialog = false
+                scope.launch {
+                    runCatching {
+                        AppContainer.venueSpaceService.add(
+                            venueId,
+                            CreateVenueSpaceRequest(label = label, type = type, capacity = capacity)
+                        )
+                    }.onSuccess { spaces.add(it) }
+                        .onFailure { CrashReporter.log(it) }
+                }
+            }
+        )
+    }
+
+    val navigator = LocalNavigator.currentOrThrow
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Залы и пространства",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    venueLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить зал")
+            }
+        }
+
+        when {
+            loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            spaces.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Нет залов / пространств", style = MaterialTheme.typography.bodyLarge)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Нажмите «+» чтобы добавить",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(4.dp)) }
+                items(spaces) { space ->
+                    VenueSpaceRow(space)
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VenueSpaceRow(space: VenueSpaceDto) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(space.label, style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold))
+            Spacer(Modifier.height(2.dp))
+            val typeLabel = if (space.type == "SEATED") "С местами" else "Партер"
+            val capacityLabel = if (space.capacity > 0) " · ${space.capacity} мест" else ""
+            Text(
+                "$typeLabel$capacityLabel",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddVenueSpaceDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (label: String, type: String, capacity: Int) -> Unit
+) {
+    var label by remember { mutableStateOf("") }
+    var type by remember { mutableStateOf("ADMISSION") }
+    var capacityStr by remember { mutableStateOf("") }
+    var typeMenuExpanded by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Добавить зал / пространство") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text("Название") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+
+                Box {
+                    OutlinedTextField(
+                        value = if (type == "SEATED") "С местами (SEATED)" else "Партер (ADMISSION)",
+                        onValueChange = {},
+                        label = { Text("Тип") },
+                        modifier = Modifier.fillMaxWidth(),
+                        readOnly = true,
+                        singleLine = true,
+                        shape = RoundedCornerShape(12.dp),
+                        trailingIcon = {
+                            TextButton(onClick = { typeMenuExpanded = true }) {
+                                Text("Изм.")
+                            }
+                        }
+                    )
+                    DropdownMenu(
+                        expanded = typeMenuExpanded,
+                        onDismissRequest = { typeMenuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Партер (ADMISSION)") },
+                            onClick = { type = "ADMISSION"; typeMenuExpanded = false }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("С местами (SEATED)") },
+                            onClick = { type = "SEATED"; typeMenuExpanded = false }
+                        )
+                    }
+                }
+
+                OutlinedTextField(
+                    value = capacityStr,
+                    onValueChange = { if (it.all(Char::isDigit)) capacityStr = it },
+                    label = { Text("Вместимость (0 — не ограничена)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(label.trim(), type, capacityStr.toIntOrNull() ?: 0) },
+                enabled = label.isNotBlank()
+            ) { Text("Добавить") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Отмена") }
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/AboutScreen.kt
@@ -95,7 +95,7 @@ fun AboutScreen() {
             Spacer(Modifier.height(16.dp))
 
             Text(
-                "Tickets",
+                "Visit Kalmykia",
                 style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
@@ -118,7 +118,7 @@ fun AboutScreen() {
                     .background(MaterialTheme.colorScheme.surface)
                     .padding(16.dp)
             ) {
-                Text("Tickets — удобный способ покупать билеты на лучшие мероприятия Элисты: " +
+                Text("Visit Kalmykia — удобный способ покупать билеты на лучшие мероприятия Калмыкии: " +
                     "театры, кино, концерты, выставки и спорт.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -153,7 +153,7 @@ fun AboutScreen() {
             Spacer(Modifier.height(24.dp))
 
             Text(
-                "© 2026 Tickets App",
+                "© 2026 Visit Kalmykia",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.outlineVariant,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/EditProfileScreen.kt
@@ -61,8 +61,6 @@ fun EditProfileScreen() {
 
     var nameValue by remember { mutableStateOf(TextFieldValue(AppSession.userName)) }
     val name = nameValue.text
-    var cityValue by remember { mutableStateOf(TextFieldValue(AppSession.city)) }
-    val city = cityValue.text
     var selectedInterests by remember { mutableStateOf(AppSession.userInterests.toSet()) }
     var saving by remember { mutableStateOf(false) }
     var saveError by remember { mutableStateOf<String?>(null) }
@@ -123,17 +121,6 @@ fun EditProfileScreen() {
                 shape = RoundedCornerShape(12.dp)
             )
 
-            Spacer(Modifier.height(16.dp))
-
-            FieldLabel("Город")
-            OutlinedTextField(
-                value = cityValue,
-                onValueChange = { cityValue = it },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp)
-            )
-
             Spacer(Modifier.height(24.dp))
 
             FieldLabel("Интересы")
@@ -189,7 +176,6 @@ fun EditProfileScreen() {
                             AppSession.userName = updated.fullName
                             AppSession.userInterests = updated.interests
                             AppSession.userAvatarUrl = updated.avatarUrl
-                            AppSession.city = city.trim().ifBlank { AppSession.city }
                             navigator.pop()
                         } catch (e: Exception) {
                             CrashReporter.log(e)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -197,7 +197,7 @@ private fun SearchResultRow(event: EventDto, onClick: () -> Unit) {
             )
             Spacer(Modifier.height(2.dp))
             Text(
-                text = event.venueId.venueShort(),
+                text = event.venueLabel ?: event.venueId.venueShort(),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1

--- a/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/karrad/ticketsclient/AppSessionTest.kt
@@ -70,7 +70,7 @@ class AppSessionTest {
     }
 
     @Test
-    fun `city has default value Moskva`() {
-        assertEquals("Москва", AppSession.city)
+    fun `city has default value Elista`() {
+        assertEquals("Элиста", AppSession.city)
     }
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -12,6 +12,7 @@ import com.karrad.ticketsclient.data.api.FakeOrgMemberService
 import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.FakeVenueAccessGrantService
 import com.karrad.ticketsclient.data.api.FakeVenueApplicationService
+import com.karrad.ticketsclient.data.api.FakeVenueSpaceService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
 
@@ -31,6 +32,7 @@ fun initContainer(baseUrl: String) {
         favoriteService = FakeFavoriteService(),
         orgMemberService = FakeOrgMemberService(),
         venueAccessGrantService = FakeVenueAccessGrantService(),
-        venueApplicationService = FakeVenueApplicationService()
+        venueApplicationService = FakeVenueApplicationService(),
+        venueSpaceService = FakeVenueSpaceService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueSpaceService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueSpaceService.kt
@@ -1,0 +1,24 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
+import java.util.UUID
+
+class FakeVenueSpaceService : VenueSpaceService {
+
+    private val storage = mutableMapOf<String, MutableList<VenueSpaceDto>>()
+
+    override suspend fun list(venueId: String): List<VenueSpaceDto> =
+        storage[venueId] ?: emptyList()
+
+    override suspend fun add(venueId: String, request: CreateVenueSpaceRequest): VenueSpaceDto {
+        val space = VenueSpaceDto(
+            id = UUID.randomUUID().toString(),
+            label = request.label,
+            type = request.type,
+            capacity = request.capacity
+        )
+        storage.getOrPut(venueId) { mutableListOf() }.add(space)
+        return space
+    }
+}


### PR DESCRIPTION
## Summary
- `VenueSpaceDto` / `CreateVenueSpaceRequest` с полями `type` (SEATED/ADMISSION) и `capacity`
- `VenueSpaceApiService`: `GET /venues/{id}/spaces` и `POST /venues/{id}/spaces`
- `FakeVenueSpaceService` для mock-режима
- `VenueSpacesScreen`: список залов/пространств с диалогом добавления
- В `OrgManagementScreen` — секция «Площадки» с кнопкой «Залы» ведущей на VenueSpacesScreen

## Test plan
- [ ] В управлении организацией видна секция «Площадки» со списком venue
- [ ] Кнопка «Залы» открывает VenueSpacesScreen для выбранной площадки
- [ ] Диалог добавления: выбор SEATED/ADMISSION, ввод вместимости
- [ ] После добавления зал появляется в списке
- [ ] Тип «С местами» и «Партер» отображается в строке зала

🤖 Generated with [Claude Code](https://claude.com/claude-code)