### PR TITLE
feat(#319): настройка типов билетов после создания мероприятия

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
+import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -55,6 +56,13 @@ class EventApiService(
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()
+
+    override suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest) {
+        httpClient.post("$baseUrl/api/v1/events/$eventId/inventory/general-admission") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+    }
 
     override suspend fun uploadCover(eventId: String, file: FileBytes) {
         httpClient.post("$baseUrl/api/v1/events/$eventId/cover") {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
+import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -19,4 +20,5 @@ interface EventService {
     suspend fun getSeatMap(eventId: String): SeatMapDto
     suspend fun createEvent(request: CreateEventRequest): EventDto
     suspend fun uploadCover(eventId: String, file: FileBytes)
+    suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketTypeDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/TicketTypeDto.kt
@@ -10,3 +10,15 @@ data class TicketTypeDto(
     val quota: Int,
     val available: Int
 )
+
+@Serializable
+data class CreateTicketTypeRequest(
+    val label: String,
+    val price: Int,
+    val quota: Int
+)
+
+@Serializable
+data class CreateGeneralAdmissionInventoryRequest(
+    val ticketTypes: List<CreateTicketTypeRequest>
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -137,3 +137,9 @@ object CreateEventScreen : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.CreateEventScreen()
 }
+
+// Setup inventory plan after event creation (OWNER/MANAGER)
+data class SetupInventoryScreen(val eventId: String) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.SetupInventoryScreen(eventId)
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
@@ -81,8 +81,9 @@ fun CreateEventScreen() {
     var coverFile by remember { mutableStateOf<FileBytes?>(null) }
     val pickCover = rememberFilePicker { files -> coverFile = files.firstOrNull() }
 
-    LaunchedEffect(state.success) {
-        if (state.success) navigator.pop()
+    LaunchedEffect(state.createdEventId) {
+        val eventId = state.createdEventId ?: return@LaunchedEffect
+        navigator.replace(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(eventId))
     }
 
     Column(

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
@@ -21,7 +21,7 @@ data class CreateEventState(
     val isLoading: Boolean = true,
     val isSubmitting: Boolean = false,
     val error: String? = null,
-    val success: Boolean = false
+    val createdEventId: String? = null
 )
 
 class CreateEventViewModel(
@@ -73,7 +73,7 @@ class CreateEventViewModel(
                     )
                 )
                 eventService.uploadCover(event.id, coverFile)
-                _state.value = _state.value.copy(isSubmitting = false, success = true)
+                _state.value = _state.value.copy(isSubmitting = false, createdEventId = event.id)
             } catch (e: Exception) {
                 CrashReporter.log(e)
                 _state.value = _state.value.copy(isSubmitting = false, error = e.message)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/SetupInventoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/SetupInventoryScreen.kt
@@ -1,0 +1,306 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
+import com.karrad.ticketsclient.data.api.dto.CreateTicketTypeRequest
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun SetupInventoryScreen(eventId: String) {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+    val ticketTypes = remember { mutableStateListOf<CreateTicketTypeRequest>() }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var isSubmitting by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    if (showAddDialog) {
+        AddTicketTypeDialog(
+            onDismiss = { showAddDialog = false },
+            onConfirm = { label, price, quota ->
+                ticketTypes.add(CreateTicketTypeRequest(label = label, price = price, quota = quota))
+                showAddDialog = false
+            }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Типы билетов",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    "Настройте цены и квоты",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить тип")
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            item { Spacer(Modifier.height(4.dp)) }
+
+            if (ticketTypes.isEmpty()) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 48.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                "Нет типов билетов",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                "Нажмите «+» чтобы добавить",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            } else {
+                items(ticketTypes) { tt ->
+                    TicketTypeRow(
+                        ticketType = tt,
+                        onDelete = { ticketTypes.remove(tt) }
+                    )
+                }
+            }
+
+            if (error != null) {
+                item {
+                    Text(
+                        "Ошибка: $error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+
+            item { Spacer(Modifier.height(8.dp)) }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = {
+                    isSubmitting = true
+                    error = null
+                    scope.launch {
+                        runCatching {
+                            AppContainer.eventService.createGeneralAdmissionInventory(
+                                eventId = eventId,
+                                request = CreateGeneralAdmissionInventoryRequest(ticketTypes = ticketTypes.toList())
+                            )
+                        }.onSuccess {
+                            navigator.pop()
+                        }.onFailure {
+                            CrashReporter.log(it)
+                            error = it.message
+                            isSubmitting = false
+                        }
+                    }
+                },
+                enabled = ticketTypes.isNotEmpty() && !isSubmitting,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(16.dp)
+                            .padding(end = 8.dp),
+                        strokeWidth = 2.dp
+                    )
+                }
+                Text("Сохранить")
+            }
+
+            OutlinedButton(
+                onClick = { navigator.pop() },
+                enabled = !isSubmitting,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Пропустить")
+            }
+        }
+    }
+}
+
+@Composable
+private fun TicketTypeRow(
+    ticketType: CreateTicketTypeRequest,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                ticketType.label,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "${ticketType.price} ₽ · ${ticketType.quota} мест",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Outlined.Delete,
+                contentDescription = "Удалить",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddTicketTypeDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (label: String, price: Int, quota: Int) -> Unit
+) {
+    var label by remember { mutableStateOf("") }
+    var priceStr by remember { mutableStateOf("") }
+    var quotaStr by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Добавить тип билета") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text("Название (напр. «Входной»)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                OutlinedTextField(
+                    value = priceStr,
+                    onValueChange = { if (it.all(Char::isDigit)) priceStr = it },
+                    label = { Text("Цена (₽)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                OutlinedTextField(
+                    value = quotaStr,
+                    onValueChange = { if (it.all(Char::isDigit)) quotaStr = it },
+                    label = { Text("Количество мест") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onConfirm(
+                        label.trim(),
+                        priceStr.toIntOrNull() ?: 0,
+                        quotaStr.toIntOrNull() ?: 0
+                    )
+                },
+                enabled = label.isNotBlank() && priceStr.isNotBlank() && quotaStr.isNotBlank()
+            ) { Text("Добавить") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Отмена") }
+        }
+    )
+}

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
+import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatItemDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
@@ -81,4 +82,6 @@ class FakeEventService : EventService {
         )
 
     override suspend fun uploadCover(eventId: String, file: FileBytes) { /* no-op in mock */ }
+
+    override suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest) { /* no-op in mock */ }
 }


### PR DESCRIPTION
## Summary
- После создания ивента в `CreateEventScreen` пользователь автоматически переходит на новый экран `SetupInventoryScreen` (вместо pop)
- На экране можно добавить типы билетов (название, цена, квота) через диалог, удалить любой
- «Сохранить» — отправляет `POST /api/v1/events/{eventId}/inventory/general-admission` и возвращается назад
- «Пропустить» — возвращается назад без создания инвентаря (настроить позже через админку)

## Changes
- `TicketTypeDto.kt` — добавлены `CreateTicketTypeRequest`, `CreateGeneralAdmissionInventoryRequest`
- `EventService` — новый метод `createGeneralAdmissionInventory()`
- `EventApiService` — реализация через Ktor POST
- `FakeEventService` — no-op заглушка
- `CreateEventViewModel` — `success: Boolean` → `createdEventId: String?`
- `CreateEventScreen` — переход на `SetupInventoryScreen` при успехе
- `SetupInventoryScreen` — новый экран (зарегистрирован в `AppScreen`)

## Test plan
- [ ] Создать мероприятие → автоматически открывается экран «Типы билетов»
- [ ] Добавить 2-3 типа через диалог (название, цена, количество мест)
- [ ] Нажать «Сохранить» → запрос к беку → возврат назад
- [ ] Нажать «Пропустить» → возврат без создания инвентаря
- [ ] Тесты: `./gradlew :composeApp:testMockDebugUnitTest` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)