### PR TITLE
feat(#194,#195): секция мероприятий орги и имя участника в OrgManagementScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberApiService.kt
@@ -3,6 +3,7 @@ package com.karrad.ticketsclient.data.api
 import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneRequest
 import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneResponse
 import com.karrad.ticketsclient.data.api.dto.AddMemberRequest
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.api.dto.UpdateMemberRequest
@@ -33,6 +34,9 @@ class OrgMemberApiService(
 
     override suspend fun listMyVenues(): List<VenueDto> =
         httpClient.get("$baseUrl/api/v1/my/organization/venues").body()
+
+    override suspend fun listMyEvents(): List<OrgEventItem> =
+        httpClient.get("$baseUrl/api/v1/my/organization/events").body()
 
     override suspend fun addMemberByPhone(phone: String, role: String, venueId: String?): AddMemberByPhoneResponse =
         httpClient.post("$baseUrl/api/v1/my/organization/members/by-phone") {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/OrgMemberService.kt
@@ -2,6 +2,7 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneRequest
 import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneResponse
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.api.dto.VenueDto
@@ -15,6 +16,9 @@ interface OrgMemberService {
 
     /** Список площадок организации текущего пользователя. */
     suspend fun listMyVenues(): List<VenueDto>
+
+    /** Список предстоящих мероприятий организации со статистикой. */
+    suspend fun listMyEvents(): List<OrgEventItem>
 
     /** Добавить участника (OWNER — любую роль; MANAGER — только STAFF). */
     suspend fun addMember(userId: String, role: String, venueId: String?): OrgMemberDto

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/OrgMemberDto.kt
@@ -16,7 +16,9 @@ data class OrgMemberDto(
     val organizationId: String,
     val userId: String,
     val role: String,
-    val venueId: String? = null
+    val venueId: String? = null,
+    val fullName: String? = null,
+    val phone: String? = null
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
@@ -6,7 +6,11 @@ import kotlinx.serialization.Serializable
 data class OrgEventItem(
     val id: String,
     val label: String,
-    val time: String
+    val time: String,
+    val venueLabel: String? = null,
+    val hasInventory: Boolean = false,
+    val sold: Int = 0,
+    val capacity: Int = 0
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -59,11 +59,13 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.navigation.VenueSpacesScreen
 import com.karrad.ticketsclient.ui.screen.auth.normalizePhone
+import com.karrad.ticketsclient.ui.util.formatEventTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -187,6 +189,26 @@ fun OrgManagementScreen() {
                                     Text("Залы", style = MaterialTheme.typography.labelMedium)
                                 }
                             }
+                        }
+                        item { Spacer(Modifier.height(4.dp)) }
+                    }
+                    if (state.events.isNotEmpty()) {
+                        item {
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                "Предстоящие мероприятия",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 4.dp)
+                            )
+                        }
+                        items(state.events) { event ->
+                            OrgEventRow(
+                                event = event,
+                                onSetupInventory = {
+                                    navigator.push(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(event.id))
+                                }
+                            )
                         }
                         item { Spacer(Modifier.height(4.dp)) }
                     }
@@ -408,6 +430,48 @@ fun OrgManagementScreen() {
 }
 
 @Composable
+private fun OrgEventRow(
+    event: OrgEventItem,
+    onSetupInventory: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                event.label,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                maxLines = 1
+            )
+            Text(
+                buildString {
+                    append(event.time.formatEventTime())
+                    if (event.venueLabel != null) append(" · ${event.venueLabel}")
+                    if (event.hasInventory) append(" · ${event.sold}/${event.capacity}")
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        if (!event.hasInventory) {
+            OutlinedButton(
+                onClick = onSetupInventory,
+                modifier = Modifier.height(32.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp)
+            ) {
+                Text("Билеты", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}
+
+@Composable
 fun MemberRow(
     member: OrgMemberDto,
     canDelete: Boolean,
@@ -442,14 +506,14 @@ fun MemberRow(
                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
             )
             Text(
-                text = member.userId,
+                text = member.fullName ?: member.phone ?: member.userId,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1
             )
-            if (member.venueId != null) {
+            if (member.phone != null && member.fullName != null) {
                 Text(
-                    text = "Площадка: ${member.venueId}",
+                    text = member.phone,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.OrgMemberService
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.VenueDto
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +15,7 @@ import kotlinx.coroutines.launch
 data class OrgManagementState(
     val members: List<OrgMemberDto> = emptyList(),
     val venues: List<VenueDto> = emptyList(),
+    val events: List<OrgEventItem> = emptyList(),
     val isLoading: Boolean = true,
     val error: String? = null,
     val addError: String? = null,
@@ -39,7 +41,8 @@ class OrgManagementViewModel(
             try {
                 val members = orgMemberService.listMembers()
                 val venues = try { orgMemberService.listMyVenues() } catch (_: Exception) { emptyList() }
-                _state.value = OrgManagementState(members = members, venues = venues, isLoading = false)
+                val events = try { orgMemberService.listMyEvents() } catch (_: Exception) { emptyList() }
+                _state.value = OrgManagementState(members = members, venues = venues, events = events, isLoading = false)
             } catch (e: Exception) {
                 CrashReporter.log(e)
                 _state.value = OrgManagementState(isLoading = false, error = e.message)

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.AddMemberByPhoneResponse
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.data.api.dto.OrgMemberDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.api.dto.VenueDto
@@ -58,4 +59,9 @@ class FakeOrgMemberService : OrgMemberService {
     override suspend fun leaveOrganization() {
         members.removeAll { it.userId == "user-owner" }
     }
+
+    override suspend fun listMyEvents(): List<OrgEventItem> = listOf(
+        OrgEventItem(id = "event-1", label = "Фестиваль «Тюльпан»", time = "2026-06-01T12:00:00Z", venueLabel = "Большой зал", hasInventory = true, sold = 42, capacity = 100),
+        OrgEventItem(id = "event-2", label = "Концерт народной музыки", time = "2026-06-15T18:00:00Z", venueLabel = "Малый зал", hasInventory = false, sold = 0, capacity = 0)
+    )
 }


### PR DESCRIPTION
## Summary

### #195 — Имя участника вместо UUID
- `OrgMemberDto` расширен полями `fullName` и `phone` (nullable, с дефолтом)
- `MemberRow` теперь показывает `fullName ?: phone ?: userId`

### #194 — Список мероприятий организации
- `OrgEventItem` расширен: `venueLabel`, `hasInventory`, `sold`, `capacity`
- `OrgMemberService.listMyEvents()` — новый метод, `GET /api/v1/my/organization/events`
- `OrgManagementViewModel` загружает события при инициализации
- В `OrgManagementScreen` добавлена секция «Предстоящие мероприятия»:
  - Название, дата, площадка, счётчик продаж `sold/capacity`
  - Кнопка «Билеты» для ивентов без инвентаря → `SetupInventoryScreen`

## Depends on
- Backend PR #324 (fullName/phone в members)
- Backend PR #325 (venueLabel/stats в events)

## Test plan
- [ ] OrgManagementScreen: участники показывают имя вместо UUID
- [ ] OrgManagementScreen: секция мероприятий видна (mock: 2 ивента)
- [ ] Ивент без инвентаря: кнопка «Билеты» → SetupInventoryScreen
- [ ] Ивент с инвентарём: показывает `sold/capacity`, без кнопки
- [ ] `./gradlew :composeApp:testMockDebugUnitTest` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)