### PR TITLE
feat(#201): пункт меню «Мои мероприятия» для STAFF в ProfileScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -149,3 +149,9 @@ data class SetupInventoryScreen(val eventId: String) : Screen {
     @androidx.compose.runtime.Composable
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.SetupInventoryScreen(eventId)
 }
+
+// Scanner (STAFF/OWNER entry point from profile)
+object ScannerScreenNav : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.scanner.ScannerScreen()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/profile/ProfileScreen.kt
@@ -176,6 +176,10 @@ fun ProfileScreen() {
                         label = "Сотрудники",
                         onClick = { rootNavigator.push(MemberManagementScreen) }
                     )
+                    "STAFF" -> MenuItem(
+                        label = "Мои мероприятия",
+                        onClick = { rootNavigator.push(com.karrad.ticketsclient.ui.navigation.ScannerScreenNav) }
+                    )
                 }
             }
             Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## Summary

- Добавлен `ScannerScreenNav` в `AppScreen.kt` — оборачивает `ScannerScreen()` как Voyager `Screen`
- В `ProfileScreen.kt` добавлен кейс `"STAFF"` в `when (membership.role)`: пункт «Мои мероприятия» открывает сканер

## Test plan

- [ ] Войти под учётной записью с ролью STAFF
- [ ] Открыть вкладку «Профиль» → появляется пункт «Мои мероприятия»
- [ ] Нажать «Мои мероприятия» → открывается экран сканера с ивентами только своей площадки
- [ ] Повернуть телефон → нет краша (ScannerScreenNav зарегистрирован)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)