### PR TITLE
feat(#203,#204): построитель рассадки и SEATED-инвентарь для мероприятий

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -2,6 +2,7 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
+import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -59,6 +60,13 @@ class EventApiService(
 
     override suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest) {
         httpClient.post("$baseUrl/api/v1/events/$eventId/inventory/general-admission") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+    }
+
+    override suspend fun createSeatedInventory(eventId: String, request: CreateSeatedInventoryRequest) {
+        httpClient.post("$baseUrl/api/v1/events/$eventId/inventory/seated") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -2,6 +2,7 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
+import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -21,4 +22,5 @@ interface EventService {
     suspend fun createEvent(request: CreateEventRequest): EventDto
     suspend fun uploadCover(eventId: String, file: FileBytes)
     suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest)
+    suspend fun createSeatedInventory(eventId: String, request: CreateSeatedInventoryRequest)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/LayoutTemplateApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/LayoutTemplateApiService.kt
@@ -1,0 +1,29 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateLayoutTemplateRequest
+import com.karrad.ticketsclient.data.api.dto.LayoutTemplateDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+
+class LayoutTemplateApiService(
+    private val httpClient: HttpClient,
+    private val baseUrl: String
+) : LayoutTemplateService {
+
+    override suspend fun list(venueSpaceId: String): List<LayoutTemplateDto> =
+        httpClient.get("$baseUrl/api/v1/layout-templates") {
+            parameter("venueSpaceId", venueSpaceId)
+        }.body()
+
+    override suspend fun create(request: CreateLayoutTemplateRequest): LayoutTemplateDto =
+        httpClient.post("$baseUrl/api/v1/layout-templates") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/LayoutTemplateService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/LayoutTemplateService.kt
@@ -1,0 +1,9 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateLayoutTemplateRequest
+import com.karrad.ticketsclient.data.api.dto.LayoutTemplateDto
+
+interface LayoutTemplateService {
+    suspend fun list(venueSpaceId: String): List<LayoutTemplateDto>
+    suspend fun create(request: CreateLayoutTemplateRequest): LayoutTemplateDto
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/LayoutTemplateDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/LayoutTemplateDto.kt
@@ -1,0 +1,41 @@
+package com.karrad.ticketsclient.data.api.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LayoutTemplateDto(
+    val id: String,
+    val venueSpaceId: String,
+    val label: String,
+    val sections: List<SectionDto> = emptyList()
+)
+
+@Serializable
+data class SectionDto(
+    val label: String,
+    val key: String,
+    val rows: List<RowDto> = emptyList()
+)
+
+@Serializable
+data class RowDto(
+    val label: String,
+    val key: String,
+    val startSeat: Int,
+    val endSeat: Int,
+    val price: Int
+) {
+    val seatCount: Int get() = endSeat - startSeat + 1
+}
+
+@Serializable
+data class CreateLayoutTemplateRequest(
+    val venueSpaceId: String,
+    val label: String,
+    val sections: List<SectionDto>
+)
+
+@Serializable
+data class CreateSeatedInventoryRequest(
+    val layoutTemplateId: String
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
@@ -8,6 +8,7 @@ data class OrgEventItem(
     val label: String,
     val time: String,
     val venueLabel: String? = null,
+    val venueSpaceId: String? = null,
     val hasInventory: Boolean = false,
     val sold: Int = 0,
     val capacity: Int = 0

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/di/AppContainer.kt
@@ -24,6 +24,8 @@ import com.karrad.ticketsclient.data.api.VenueAccessGrantApiService
 import com.karrad.ticketsclient.data.api.VenueAccessGrantService
 import com.karrad.ticketsclient.data.api.VenueApplicationApiService
 import com.karrad.ticketsclient.data.api.VenueApplicationService
+import com.karrad.ticketsclient.data.api.LayoutTemplateApiService
+import com.karrad.ticketsclient.data.api.LayoutTemplateService
 import com.karrad.ticketsclient.data.api.VenueSpaceApiService
 import com.karrad.ticketsclient.data.api.VenueSpaceService
 import com.karrad.ticketsclient.AppSession
@@ -80,6 +82,9 @@ object AppContainer {
     lateinit var venueSpaceService: VenueSpaceService
         private set
 
+    lateinit var layoutTemplateService: LayoutTemplateService
+        private set
+
     lateinit var httpClient: io.ktor.client.HttpClient
         private set
 
@@ -99,7 +104,8 @@ object AppContainer {
         orgMemberService: OrgMemberService,
         venueAccessGrantService: VenueAccessGrantService,
         venueApplicationService: VenueApplicationService,
-        venueSpaceService: VenueSpaceService
+        venueSpaceService: VenueSpaceService,
+        layoutTemplateService: LayoutTemplateService
     ) {
         this.isMock = isMock
         this.baseUrl = baseUrl
@@ -117,6 +123,7 @@ object AppContainer {
         this.venueAccessGrantService = venueAccessGrantService
         this.venueApplicationService = venueApplicationService
         this.venueSpaceService = venueSpaceService
+        this.layoutTemplateService = layoutTemplateService
     }
 }
 
@@ -138,6 +145,7 @@ fun AppContainer.initReal(baseUrl: String) {
         orgMemberService = OrgMemberApiService(client, baseUrl),
         venueAccessGrantService = VenueAccessGrantApiService(client, baseUrl),
         venueApplicationService = VenueApplicationApiService(client, baseUrl),
-        venueSpaceService = VenueSpaceApiService(client, baseUrl)
+        venueSpaceService = VenueSpaceApiService(client, baseUrl),
+        layoutTemplateService = LayoutTemplateApiService(client, baseUrl)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -145,9 +145,15 @@ data class VenueSpacesScreen(val venueId: String, val venueLabel: String) : Scre
 }
 
 // Setup inventory plan after event creation (OWNER/MANAGER)
-data class SetupInventoryScreen(val eventId: String) : Screen {
+data class SetupInventoryScreen(val eventId: String, val venueSpaceId: String? = null) : Screen {
     @androidx.compose.runtime.Composable
-    override fun Content() = com.karrad.ticketsclient.ui.screen.org.SetupInventoryScreen(eventId)
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.SetupInventoryScreen(eventId, venueSpaceId)
+}
+
+// Layout template builder for SEATED venue spaces
+data class LayoutTemplateBuilderScreen(val venueSpaceId: String, val venueSpaceLabel: String) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.LayoutTemplateBuilderScreen(venueSpaceId, venueSpaceLabel)
 }
 
 // Scanner (STAFF/OWNER entry point from profile)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/LayoutTemplateBuilderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/LayoutTemplateBuilderScreen.kt
@@ -1,0 +1,443 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.CreateLayoutTemplateRequest
+import com.karrad.ticketsclient.data.api.dto.RowDto
+import com.karrad.ticketsclient.data.api.dto.SectionDto
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun LayoutTemplateBuilderScreen(venueSpaceId: String, venueSpaceLabel: String) {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var templateLabel by remember { mutableStateOf("") }
+    val sections = remember { mutableStateListOf<SectionDraft>() }
+
+    var showAddSectionDialog by remember { mutableStateOf(false) }
+    var addRowForSectionIndex by remember { mutableStateOf<Int?>(null) }
+
+    var isSubmitting by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    if (showAddSectionDialog) {
+        AddSectionDialog(
+            onDismiss = { showAddSectionDialog = false },
+            onConfirm = { label, key ->
+                sections.add(SectionDraft(label = label, key = key))
+                showAddSectionDialog = false
+            }
+        )
+    }
+
+    val rowSectionIdx = addRowForSectionIndex
+    if (rowSectionIdx != null) {
+        AddRowDialog(
+            onDismiss = { addRowForSectionIndex = null },
+            onConfirm = { label, key, start, end, price ->
+                sections[rowSectionIdx] = sections[rowSectionIdx].copy(
+                    rows = sections[rowSectionIdx].rows + RowDto(label, key, start, end, price)
+                )
+                addRowForSectionIndex = null
+            }
+        )
+    }
+
+    val canSave = templateLabel.isNotBlank() && sections.isNotEmpty() && sections.all { it.rows.isNotEmpty() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Схема рассадки",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    venueSpaceLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            IconButton(onClick = { showAddSectionDialog = true }) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить секцию")
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            item {
+                OutlinedTextField(
+                    value = templateLabel,
+                    onValueChange = { templateLabel = it },
+                    label = { Text("Название схемы") },
+                    placeholder = { Text("напр. «Основная схема»") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+
+            if (sections.isEmpty()) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("Нет секций", style = MaterialTheme.typography.bodyLarge)
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                "Нажмите «+» чтобы добавить секцию (ВИП, Партер, Балкон…)",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            itemsIndexed(sections) { sectionIdx, section ->
+                SectionCard(
+                    section = section,
+                    onAddRow = { addRowForSectionIndex = sectionIdx },
+                    onDeleteRow = { rowIdx ->
+                        sections[sectionIdx] = section.copy(
+                            rows = section.rows.toMutableList().also { it.removeAt(rowIdx) }
+                        )
+                    },
+                    onDeleteSection = { sections.removeAt(sectionIdx) }
+                )
+            }
+
+            if (error != null) {
+                item {
+                    Text(
+                        "Ошибка: $error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+
+            item { Spacer(Modifier.height(8.dp)) }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = {
+                    isSubmitting = true
+                    error = null
+                    scope.launch {
+                        runCatching {
+                            AppContainer.layoutTemplateService.create(
+                                CreateLayoutTemplateRequest(
+                                    venueSpaceId = venueSpaceId,
+                                    label = templateLabel.trim(),
+                                    sections = sections.map { s ->
+                                        SectionDto(label = s.label, key = s.key, rows = s.rows)
+                                    }
+                                )
+                            )
+                        }.onSuccess {
+                            navigator.pop()
+                        }.onFailure {
+                            CrashReporter.log(it)
+                            error = it.message
+                            isSubmitting = false
+                        }
+                    }
+                },
+                enabled = canSave && !isSubmitting,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isSubmitting) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                else Text("Сохранить схему")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionCard(
+    section: SectionDraft,
+    onAddRow: () -> Unit,
+    onDeleteRow: (Int) -> Unit,
+    onDeleteSection: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                section.label,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                "key: ${section.key}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            IconButton(onClick = onAddRow, modifier = Modifier.size(32.dp)) {
+                Icon(Icons.Outlined.Add, contentDescription = "Добавить ряд", modifier = Modifier.size(18.dp))
+            }
+            IconButton(onClick = onDeleteSection, modifier = Modifier.size(32.dp)) {
+                Icon(
+                    Icons.Outlined.Delete,
+                    contentDescription = "Удалить секцию",
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+
+        if (section.rows.isNotEmpty()) {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            section.rows.forEachIndexed { rowIdx, row ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(row.label, style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium))
+                        Text(
+                            "места ${row.startSeat}–${row.endSeat} · ${row.price} ₽",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = { onDeleteRow(rowIdx) }, modifier = Modifier.size(32.dp)) {
+                        Icon(
+                            Icons.Outlined.Delete,
+                            contentDescription = "Удалить ряд",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+                if (rowIdx < section.rows.lastIndex) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                }
+            }
+        } else {
+            Text(
+                "Нет рядов — нажмите «+»",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddSectionDialog(onDismiss: () -> Unit, onConfirm: (label: String, key: String) -> Unit) {
+    var label by remember { mutableStateOf("") }
+    var key by remember { mutableStateOf("") }
+    var keyEditedManually by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Добавить секцию") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = {
+                        label = it
+                        if (!keyEditedManually) key = it.lowercase().replace(" ", "_")
+                    },
+                    label = { Text("Название (напр. «ВИП», «Партер»)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                OutlinedTextField(
+                    value = key,
+                    onValueChange = { key = it; keyEditedManually = true },
+                    label = { Text("Ключ (латиница, уникален)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(label.trim(), key.trim()) },
+                enabled = label.isNotBlank() && key.isNotBlank()
+            ) { Text("Добавить") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Отмена") } }
+    )
+}
+
+@Composable
+private fun AddRowDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (label: String, key: String, startSeat: Int, endSeat: Int, price: Int) -> Unit
+) {
+    var label by remember { mutableStateOf("") }
+    var key by remember { mutableStateOf("") }
+    var keyEditedManually by remember { mutableStateOf(false) }
+    var startStr by remember { mutableStateOf("1") }
+    var endStr by remember { mutableStateOf("") }
+    var priceStr by remember { mutableStateOf("") }
+
+    val start = startStr.toIntOrNull() ?: 0
+    val end = endStr.toIntOrNull() ?: 0
+    val price = priceStr.toIntOrNull() ?: 0
+    val valid = label.isNotBlank() && key.isNotBlank() && start > 0 && end >= start && price > 0
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Добавить ряд") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = {
+                        label = it
+                        if (!keyEditedManually) key = it.lowercase().replace(" ", "_")
+                    },
+                    label = { Text("Название ряда (напр. «Ряд 1»)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                OutlinedTextField(
+                    value = key,
+                    onValueChange = { key = it; keyEditedManually = true },
+                    label = { Text("Ключ ряда (латиница, уникален в секции)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = startStr,
+                        onValueChange = { if (it.all(Char::isDigit)) startStr = it },
+                        label = { Text("Место с") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    OutlinedTextField(
+                        value = endStr,
+                        onValueChange = { if (it.all(Char::isDigit)) endStr = it },
+                        label = { Text("Место по") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                }
+                OutlinedTextField(
+                    value = priceStr,
+                    onValueChange = { if (it.all(Char::isDigit)) priceStr = it },
+                    label = { Text("Цена (₽)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(label.trim(), key.trim(), start, end, price) },
+                enabled = valid
+            ) { Text("Добавить") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Отмена") } }
+    )
+}
+
+private data class SectionDraft(
+    val label: String,
+    val key: String,
+    val rows: List<RowDto> = emptyList()
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -206,7 +206,7 @@ fun OrgManagementScreen() {
                             OrgEventRow(
                                 event = event,
                                 onSetupInventory = {
-                                    navigator.push(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(event.id))
+                                    navigator.push(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(event.id, event.venueSpaceId))
                                 }
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/SetupInventoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/SetupInventoryScreen.kt
@@ -1,6 +1,8 @@
 package com.karrad.ticketsclient.ui.screen.org
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +22,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -32,6 +35,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -48,12 +52,209 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
+import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.CreateTicketTypeRequest
+import com.karrad.ticketsclient.data.api.dto.LayoutTemplateDto
 import com.karrad.ticketsclient.di.AppContainer
 import kotlinx.coroutines.launch
 
+/**
+ * @param venueSpaceId если не null — SEATED-режим: выбор шаблона рассадки.
+ *                     если null — ADMISSION-режим: добавление типов билетов.
+ */
 @Composable
-fun SetupInventoryScreen(eventId: String) {
+fun SetupInventoryScreen(eventId: String, venueSpaceId: String? = null) {
+    if (venueSpaceId != null) {
+        SeatedInventoryScreen(eventId = eventId, venueSpaceId = venueSpaceId)
+    } else {
+        AdmissionInventoryScreen(eventId = eventId)
+    }
+}
+
+// ─── SEATED ──────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SeatedInventoryScreen(eventId: String, venueSpaceId: String) {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var loading by remember { mutableStateOf(true) }
+    val templates = remember { mutableStateListOf<LayoutTemplateDto>() }
+    var loadError by remember { mutableStateOf<String?>(null) }
+    var selectedId by remember { mutableStateOf<String?>(null) }
+    var isSubmitting by remember { mutableStateOf(false) }
+    var submitError by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(venueSpaceId) {
+        loading = true
+        runCatching { AppContainer.layoutTemplateService.list(venueSpaceId) }
+            .onSuccess { templates.addAll(it) }
+            .onFailure { loadError = it.message }
+        loading = false
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Схема рассадки",
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    "Выберите шаблон для мероприятия",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        when {
+            loading -> Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            loadError != null -> Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text("Ошибка загрузки: $loadError", color = MaterialTheme.colorScheme.error)
+            }
+            templates.isEmpty() -> Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Нет шаблонов рассадки", style = MaterialTheme.typography.bodyLarge)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Сначала создайте схему зала через «Залы и пространства»",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(4.dp)) }
+                items(templates) { template ->
+                    val isSelected = template.id == selectedId
+                    val totalSeats = template.sections.sumOf { s ->
+                        s.rows.sumOf { r -> r.endSeat - r.startSeat + 1 }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(
+                                if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                                else MaterialTheme.colorScheme.surface
+                            )
+                            .border(
+                                width = if (isSelected) 2.dp else 0.dp,
+                                color = if (isSelected) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.surface,
+                                shape = RoundedCornerShape(12.dp)
+                            )
+                            .clickable { selectedId = template.id }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                template.label,
+                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                "${template.sections.size} секц. · $totalSeats мест",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        if (isSelected) {
+                            Icon(
+                                Icons.Outlined.CheckCircle,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+                }
+                if (submitError != null) {
+                    item {
+                        Text(
+                            "Ошибка: $submitError",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
+                }
+                item { Spacer(Modifier.height(8.dp)) }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                onClick = {
+                    isSubmitting = true
+                    submitError = null
+                    scope.launch {
+                        runCatching {
+                            AppContainer.eventService.createSeatedInventory(
+                                eventId = eventId,
+                                request = CreateSeatedInventoryRequest(layoutTemplateId = selectedId!!)
+                            )
+                        }.onSuccess {
+                            navigator.pop()
+                        }.onFailure {
+                            CrashReporter.log(it)
+                            submitError = it.message
+                            isSubmitting = false
+                        }
+                    }
+                },
+                enabled = selectedId != null && !isSubmitting && templates.isNotEmpty(),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (isSubmitting) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                else Text("Применить схему")
+            }
+            OutlinedButton(
+                onClick = { navigator.pop() },
+                enabled = !isSubmitting,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Пропустить")
+            }
+        }
+    }
+}
+
+// ─── ADMISSION ───────────────────────────────────────────────────────────────
+
+@Composable
+private fun AdmissionInventoryScreen(eventId: String) {
     val navigator = LocalNavigator.currentOrThrow
     val scope = rememberCoroutineScope()
     val ticketTypes = remember { mutableStateListOf<CreateTicketTypeRequest>() }
@@ -119,10 +320,7 @@ fun SetupInventoryScreen(eventId: String) {
                         contentAlignment = Alignment.Center
                     ) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                "Нет типов билетов",
-                                style = MaterialTheme.typography.bodyLarge
-                            )
+                            Text("Нет типов билетов", style = MaterialTheme.typography.bodyLarge)
                             Spacer(Modifier.height(8.dp))
                             Text(
                                 "Нажмите «+» чтобы добавить",
@@ -134,10 +332,7 @@ fun SetupInventoryScreen(eventId: String) {
                 }
             } else {
                 items(ticketTypes) { tt ->
-                    TicketTypeRow(
-                        ticketType = tt,
-                        onDelete = { ticketTypes.remove(tt) }
-                    )
+                    TicketTypeRow(ticketType = tt, onDelete = { ticketTypes.remove(tt) })
                 }
             }
 
@@ -151,7 +346,6 @@ fun SetupInventoryScreen(eventId: String) {
                     )
                 }
             }
-
             item { Spacer(Modifier.height(8.dp)) }
         }
 
@@ -186,17 +380,9 @@ fun SetupInventoryScreen(eventId: String) {
                 shape = RoundedCornerShape(12.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                if (isSubmitting) {
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .size(16.dp)
-                            .padding(end = 8.dp),
-                        strokeWidth = 2.dp
-                    )
-                }
-                Text("Сохранить")
+                if (isSubmitting) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                else Text("Сохранить")
             }
-
             OutlinedButton(
                 onClick = { navigator.pop() },
                 enabled = !isSubmitting,
@@ -210,10 +396,7 @@ fun SetupInventoryScreen(eventId: String) {
 }
 
 @Composable
-private fun TicketTypeRow(
-    ticketType: CreateTicketTypeRequest,
-    onDelete: () -> Unit
-) {
+private fun TicketTypeRow(ticketType: CreateTicketTypeRequest, onDelete: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -223,10 +406,7 @@ private fun TicketTypeRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                ticketType.label,
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
-            )
+            Text(ticketType.label, style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold))
             Spacer(Modifier.height(2.dp))
             Text(
                 "${ticketType.price} ₽ · ${ticketType.quota} мест",
@@ -290,17 +470,11 @@ private fun AddTicketTypeDialog(
         confirmButton = {
             Button(
                 onClick = {
-                    onConfirm(
-                        label.trim(),
-                        priceStr.toIntOrNull() ?: 0,
-                        quotaStr.toIntOrNull() ?: 0
-                    )
+                    onConfirm(label.trim(), priceStr.toIntOrNull() ?: 0, quotaStr.toIntOrNull() ?: 0)
                 },
                 enabled = label.isNotBlank() && priceStr.isNotBlank() && quotaStr.isNotBlank()
             ) { Text("Добавить") }
         },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Отмена") }
-        }
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Отмена") } }
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.ui.navigation.LayoutTemplateBuilderScreen
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
@@ -149,7 +150,7 @@ fun VenueSpacesScreen(venueId: String, venueLabel: String) {
             ) {
                 item { Spacer(Modifier.height(4.dp)) }
                 items(spaces) { space ->
-                    VenueSpaceRow(space)
+                    VenueSpaceRow(space, navigator)
                 }
                 item { Spacer(Modifier.height(16.dp)) }
             }
@@ -158,7 +159,7 @@ fun VenueSpacesScreen(venueId: String, venueLabel: String) {
 }
 
 @Composable
-private fun VenueSpaceRow(space: VenueSpaceDto) {
+private fun VenueSpaceRow(space: VenueSpaceDto, navigator: cafe.adriel.voyager.navigator.Navigator) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -177,6 +178,15 @@ private fun VenueSpaceRow(space: VenueSpaceDto) {
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        if (space.type == "SEATED") {
+            OutlinedButton(
+                onClick = { navigator.push(LayoutTemplateBuilderScreen(space.id, space.label)) },
+                modifier = Modifier.height(32.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp)
+            ) {
+                Text("Схема", style = MaterialTheme.typography.labelMedium)
+            }
         }
     }
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/ContainerInit.kt
@@ -13,6 +13,7 @@ import com.karrad.ticketsclient.data.api.FakeTicketService
 import com.karrad.ticketsclient.data.api.FakeVenueAccessGrantService
 import com.karrad.ticketsclient.data.api.FakeVenueApplicationService
 import com.karrad.ticketsclient.data.api.FakeVenueSpaceService
+import com.karrad.ticketsclient.data.api.FakeLayoutTemplateService
 import com.karrad.ticketsclient.data.api.createHttpClient
 import com.karrad.ticketsclient.di.AppContainer
 
@@ -33,6 +34,7 @@ fun initContainer(baseUrl: String) {
         orgMemberService = FakeOrgMemberService(),
         venueAccessGrantService = FakeVenueAccessGrantService(),
         venueApplicationService = FakeVenueApplicationService(),
-        venueSpaceService = FakeVenueSpaceService()
+        venueSpaceService = FakeVenueSpaceService(),
+        layoutTemplateService = FakeLayoutTemplateService()
     )
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -2,6 +2,7 @@ package com.karrad.ticketsclient.data.api
 
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.CreateGeneralAdmissionInventoryRequest
+import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatItemDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
@@ -84,4 +85,6 @@ class FakeEventService : EventService {
     override suspend fun uploadCover(eventId: String, file: FileBytes) { /* no-op in mock */ }
 
     override suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest) { /* no-op in mock */ }
+
+    override suspend fun createSeatedInventory(eventId: String, request: CreateSeatedInventoryRequest) { /* no-op in mock */ }
 }

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeLayoutTemplateService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeLayoutTemplateService.kt
@@ -1,0 +1,51 @@
+package com.karrad.ticketsclient.data.api
+
+import com.karrad.ticketsclient.data.api.dto.CreateLayoutTemplateRequest
+import com.karrad.ticketsclient.data.api.dto.LayoutTemplateDto
+import com.karrad.ticketsclient.data.api.dto.RowDto
+import com.karrad.ticketsclient.data.api.dto.SectionDto
+import java.util.UUID
+
+class FakeLayoutTemplateService : LayoutTemplateService {
+
+    private val storage = mutableMapOf<String, MutableList<LayoutTemplateDto>>(
+        "space-seated-1" to mutableListOf(
+            LayoutTemplateDto(
+                id = "lt-1",
+                venueSpaceId = "space-seated-1",
+                label = "Основная схема",
+                sections = listOf(
+                    SectionDto(
+                        label = "ВИП",
+                        key = "vip",
+                        rows = listOf(
+                            RowDto(label = "Ряд 1", key = "r1", startSeat = 1, endSeat = 10, price = 5000)
+                        )
+                    ),
+                    SectionDto(
+                        label = "Партер",
+                        key = "parter",
+                        rows = listOf(
+                            RowDto(label = "Ряд 1", key = "r1", startSeat = 1, endSeat = 20, price = 2000),
+                            RowDto(label = "Ряд 2", key = "r2", startSeat = 1, endSeat = 20, price = 1800)
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    override suspend fun list(venueSpaceId: String): List<LayoutTemplateDto> =
+        storage[venueSpaceId] ?: emptyList()
+
+    override suspend fun create(request: CreateLayoutTemplateRequest): LayoutTemplateDto {
+        val template = LayoutTemplateDto(
+            id = UUID.randomUUID().toString(),
+            venueSpaceId = request.venueSpaceId,
+            label = request.label,
+            sections = request.sections
+        )
+        storage.getOrPut(request.venueSpaceId) { mutableListOf() }.add(template)
+        return template
+    }
+}

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeOrgMemberService.kt
@@ -61,7 +61,7 @@ class FakeOrgMemberService : OrgMemberService {
     }
 
     override suspend fun listMyEvents(): List<OrgEventItem> = listOf(
-        OrgEventItem(id = "event-1", label = "Фестиваль «Тюльпан»", time = "2026-06-01T12:00:00Z", venueLabel = "Большой зал", hasInventory = true, sold = 42, capacity = 100),
-        OrgEventItem(id = "event-2", label = "Концерт народной музыки", time = "2026-06-15T18:00:00Z", venueLabel = "Малый зал", hasInventory = false, sold = 0, capacity = 0)
+        OrgEventItem(id = "event-1", label = "Фестиваль «Тюльпан»", time = "2026-06-01T12:00:00Z", venueLabel = "Большой зал", venueSpaceId = null, hasInventory = true, sold = 42, capacity = 100),
+        OrgEventItem(id = "event-2", label = "Концерт народной музыки", time = "2026-06-15T18:00:00Z", venueLabel = "Малый зал", venueSpaceId = "space-seated-1", hasInventory = false, sold = 0, capacity = 0)
     )
 }


### PR DESCRIPTION
## Summary

### #203 — Построитель LayoutTemplate
- `LayoutTemplateBuilderScreen` — добавление секций/рядов (название, место с/по, цена)
- `VenueSpacesScreen`: кнопка «Схема» для SEATED-залов
- `POST /api/v1/layout-templates`

### #204 — SEATED-ветка в SetupInventoryScreen
- `SetupInventoryScreen(eventId, venueSpaceId)`: если venueSpaceId != null — выбор шаблона рассадки
- `POST /api/v1/events/{id}/inventory/seated` после выбора
- ADMISSION-ветка без изменений

### Общее
- `OrgEventItem.venueSpaceId` из бека
- `FakeLayoutTemplateService` с демо-шаблоном

Closes #203, #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)