### PR TITLE
fix: импорт OutlinedButton в VenueSpacesScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton


### PR DESCRIPTION
Пропущен import androidx.compose.material3.OutlinedButton в VenueSpacesScreen.kt → сломал CI после PR #205.