### PR TITLE
feat(#208): редизайн флоу создания и управления мероприятием

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventApiService.kt
@@ -6,10 +6,12 @@ import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
+import com.karrad.ticketsclient.data.api.dto.UpdateEventRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -54,6 +56,12 @@ class EventApiService(
 
     override suspend fun createEvent(request: CreateEventRequest): EventDto =
         httpClient.post("$baseUrl/api/v1/events") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
+
+    override suspend fun updateEvent(eventId: String, request: UpdateEventRequest): EventDto =
+        httpClient.patch("$baseUrl/api/v1/events/$eventId") {
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/EventService.kt
@@ -6,6 +6,7 @@ import com.karrad.ticketsclient.data.api.dto.CreateSeatedInventoryRequest
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
+import com.karrad.ticketsclient.data.api.dto.UpdateEventRequest
 
 interface EventService {
     suspend fun getEvent(eventId: String): EventDto
@@ -21,6 +22,7 @@ interface EventService {
     suspend fun getSeatMap(eventId: String): SeatMapDto
     suspend fun createEvent(request: CreateEventRequest): EventDto
     suspend fun uploadCover(eventId: String, file: FileBytes)
+    suspend fun updateEvent(eventId: String, request: UpdateEventRequest): EventDto
     suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest)
     suspend fun createSeatedInventory(eventId: String, request: CreateSeatedInventoryRequest)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
@@ -34,5 +34,15 @@ data class CreateEventRequest(
     val categoryId: String,
     val time: String,
     val imageUrl: String? = null,
+    val ageRating: String? = null,
+    val venueSpaceId: String? = null,
+    val hasSeatMap: Boolean? = null
+)
+
+@Serializable
+data class UpdateEventRequest(
+    val label: String? = null,
+    val description: String? = null,
+    val time: String? = null,
     val ageRating: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -156,6 +156,18 @@ data class LayoutTemplateBuilderScreen(val venueSpaceId: String, val venueSpaceL
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.LayoutTemplateBuilderScreen(venueSpaceId, venueSpaceLabel)
 }
 
+// Event management (OWNER/MANAGER — stats + buttons)
+data class EventManagementScreen(val event: com.karrad.ticketsclient.data.api.dto.OrgEventItem) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.EventManagementScreen(event)
+}
+
+// Edit event (OWNER/MANAGER)
+data class EditEventScreen(val eventId: String) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.EditEventScreen(eventId)
+}
+
 // Scanner (STAFF/OWNER entry point from profile)
 object ScannerScreenNav : Screen {
     @androidx.compose.runtime.Composable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
@@ -62,7 +62,8 @@ fun CreateEventScreen() {
         CreateEventViewModel(
             AppContainer.eventService,
             AppContainer.orgMemberService,
-            AppContainer.geoService
+            AppContainer.geoService,
+            AppContainer.venueSpaceService
         )
     }
     val state by vm.state.collectAsState()
@@ -78,12 +79,16 @@ fun CreateEventScreen() {
     var timeText by remember { mutableStateOf("") }
     var venueMenuExpanded by remember { mutableStateOf(false) }
     var categoryMenuExpanded by remember { mutableStateOf(false) }
+    var spaceMenuExpanded by remember { mutableStateOf(false) }
+    var selectedSpaceId by remember { mutableStateOf<String?>(null) }
+    var selectedSpaceLabel by remember { mutableStateOf("Выберите зал / пространство") }
+    var selectedSpaceType by remember { mutableStateOf("ADMISSION") }
     var coverFile by remember { mutableStateOf<FileBytes?>(null) }
     val pickCover = rememberFilePicker { files -> coverFile = files.firstOrNull() }
 
     LaunchedEffect(state.createdEventId) {
         val eventId = state.createdEventId ?: return@LaunchedEffect
-        navigator.replace(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(eventId))
+        navigator.replace(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(eventId, selectedSpaceId))
     }
 
     Column(
@@ -198,6 +203,11 @@ fun CreateEventScreen() {
                                     selectedVenueId = venue.id
                                     selectedVenueLabel = venue.label
                                     venueMenuExpanded = false
+                                    // Сбросить выбор зала и загрузить новые
+                                    selectedSpaceId = null
+                                    selectedSpaceLabel = "Выберите зал / пространство"
+                                    selectedSpaceType = "ADMISSION"
+                                    vm.onVenueSelected(venue.id)
                                 }
                             )
                         }
@@ -206,6 +216,63 @@ fun CreateEventScreen() {
                                 text = { Text("Нет доступных площадок", color = MaterialTheme.colorScheme.onSurfaceVariant) },
                                 onClick = { venueMenuExpanded = false }
                             )
+                        }
+                    }
+                }
+
+                // VenueSpace selector — показывается только если загружены залы
+                if (selectedVenueId.isNotBlank() && (state.spaces.isNotEmpty() || state.spacesLoading)) {
+                    Box {
+                        OutlinedButton(
+                            onClick = { spaceMenuExpanded = true },
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled = !state.spacesLoading
+                        ) {
+                            if (state.spacesLoading) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp).padding(end = 8.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            }
+                            Text(
+                                if (state.spacesLoading) "Загрузка залов..." else selectedSpaceLabel,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = spaceMenuExpanded,
+                            onDismissRequest = { spaceMenuExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Без зала", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                                onClick = {
+                                    selectedSpaceId = null
+                                    selectedSpaceLabel = "Без зала"
+                                    selectedSpaceType = "ADMISSION"
+                                    spaceMenuExpanded = false
+                                }
+                            )
+                            state.spaces.forEach { space ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Column {
+                                            Text(space.label)
+                                            Text(
+                                                space.type,
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        selectedSpaceId = space.id
+                                        selectedSpaceLabel = space.label
+                                        selectedSpaceType = space.type
+                                        spaceMenuExpanded = false
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -283,7 +350,12 @@ fun CreateEventScreen() {
                 Button(
                     onClick = {
                         val isoTime = "${dateText}T${timeText}:00Z"
-                        vm.submit(label, description, selectedVenueId, selectedCategoryId, selectedAgeRating, isoTime, coverFile!!)
+                        vm.submit(
+                            label, description, selectedVenueId, selectedCategoryId,
+                            selectedAgeRating, isoTime, coverFile!!,
+                            venueSpaceId = selectedSpaceId,
+                            hasSeatMap = selectedSpaceType == "SEATED"
+                        )
                     },
                     enabled = canSubmit,
                     shape = RoundedCornerShape(12.dp),

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
@@ -6,9 +6,11 @@ import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.EventService
 import com.karrad.ticketsclient.data.api.FileBytes
 import com.karrad.ticketsclient.data.api.OrgMemberService
+import com.karrad.ticketsclient.data.api.VenueSpaceService
 import com.karrad.ticketsclient.data.api.dto.CategoryDto
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
 import com.karrad.ticketsclient.data.api.dto.VenueDto
+import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
 import com.karrad.ticketsclient.data.api.GeoService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +20,8 @@ import kotlinx.coroutines.launch
 data class CreateEventState(
     val venues: List<VenueDto> = emptyList(),
     val categories: List<CategoryDto> = emptyList(),
+    val spaces: List<VenueSpaceDto> = emptyList(),
+    val spacesLoading: Boolean = false,
     val isLoading: Boolean = true,
     val isSubmitting: Boolean = false,
     val error: String? = null,
@@ -27,7 +31,8 @@ data class CreateEventState(
 class CreateEventViewModel(
     private val eventService: EventService,
     private val orgMemberService: OrgMemberService,
-    private val geoService: GeoService
+    private val geoService: GeoService,
+    private val venueSpaceService: VenueSpaceService
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(CreateEventState())
@@ -50,6 +55,14 @@ class CreateEventViewModel(
         }
     }
 
+    fun onVenueSelected(venueId: String) {
+        _state.value = _state.value.copy(spacesLoading = true, spaces = emptyList())
+        viewModelScope.launch {
+            val spaces = runCatching { venueSpaceService.list(venueId) }.getOrDefault(emptyList())
+            _state.value = _state.value.copy(spaces = spaces, spacesLoading = false)
+        }
+    }
+
     fun submit(
         label: String,
         description: String,
@@ -57,7 +70,9 @@ class CreateEventViewModel(
         categoryId: String,
         ageRating: String,
         isoTime: String,
-        coverFile: FileBytes
+        coverFile: FileBytes,
+        venueSpaceId: String?,
+        hasSeatMap: Boolean
     ) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isSubmitting = true, error = null)
@@ -69,7 +84,9 @@ class CreateEventViewModel(
                         venueId = venueId,
                         categoryId = categoryId,
                         time = isoTime,
-                        ageRating = ageRating
+                        ageRating = ageRating,
+                        venueSpaceId = venueSpaceId,
+                        hasSeatMap = hasSeatMap
                     )
                 )
                 eventService.uploadCover(event.id, coverFile)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/EditEventScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/EditEventScreen.kt
@@ -1,0 +1,253 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.UpdateEventRequest
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.launch
+
+@Composable
+fun EditEventScreen(eventId: String) {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+
+    var label by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var dateText by remember { mutableStateOf("") }
+    var timeText by remember { mutableStateOf("") }
+    var ageRating by remember { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(true) }
+    var isSaving by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var saved by remember { mutableStateOf(false) }
+
+    LaunchedEffect(eventId) {
+        try {
+            val event = AppContainer.eventService.getEvent(eventId)
+            label = event.label
+            description = event.description
+            val parts = event.time.split("T")
+            dateText = parts.getOrElse(0) { "" }
+            timeText = parts.getOrElse(1) { "" }.take(5)
+            ageRating = event.ageRating ?: ""
+        } catch (e: Exception) {
+            CrashReporter.log(e)
+            error = e.message
+        } finally {
+            isLoading = false
+        }
+    }
+
+    LaunchedEffect(saved) {
+        if (saved) navigator.pop()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Редактировать мероприятие",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            else -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Spacer(Modifier.height(4.dp))
+
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text("Название") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Описание") },
+                    minLines = 3,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                OutlinedTextField(
+                    value = dateText,
+                    onValueChange = { dateText = it },
+                    label = { Text("Дата") },
+                    placeholder = { Text("2025-12-31") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                OutlinedTextField(
+                    value = timeText,
+                    onValueChange = { timeText = it },
+                    label = { Text("Время (UTC)") },
+                    placeholder = { Text("18:00") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                EditAgeRatingSelector(
+                    selected = ageRating,
+                    onSelect = { ageRating = it }
+                )
+
+                if (error != null) {
+                    Text(
+                        "Ошибка: $error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+
+                val canSave = label.isNotBlank() && description.isNotBlank() &&
+                    dateText.matches(Regex("\\d{4}-\\d{2}-\\d{2}")) &&
+                    timeText.matches(Regex("\\d{2}:\\d{2}")) &&
+                    !isSaving
+
+                Button(
+                    onClick = {
+                        isSaving = true
+                        error = null
+                        scope.launch {
+                            try {
+                                AppContainer.eventService.updateEvent(
+                                    eventId,
+                                    UpdateEventRequest(
+                                        label = label,
+                                        description = description,
+                                        time = "${dateText}T${timeText}:00Z",
+                                        ageRating = ageRating.ifBlank { null }
+                                    )
+                                )
+                                saved = true
+                            } catch (e: Exception) {
+                                CrashReporter.log(e)
+                                error = e.message
+                            } finally {
+                                isSaving = false
+                            }
+                        }
+                    },
+                    enabled = canSave,
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    if (isSaving) CircularProgressIndicator(
+                        modifier = Modifier.padding(end = 8.dp),
+                        strokeWidth = 2.dp
+                    )
+                    Text("Сохранить")
+                }
+
+                Spacer(Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+private val AGE_RATINGS_EDIT = listOf("0+", "6+", "12+", "16+", "18+")
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun EditAgeRatingSelector(selected: String, onSelect: (String) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            "Возрастное ограничение",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AGE_RATINGS_EDIT.forEach { rating ->
+                val isSelected = selected == rating
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(50))
+                        .background(
+                            if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.surfaceVariant
+                        )
+                        .clickable { onSelect(rating) }
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        rating,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isSelected) Color.White else MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/EventManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/EventManagementScreen.kt
@@ -1,0 +1,171 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.ConfirmationNumber
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
+import com.karrad.ticketsclient.ui.util.formatEventTime
+
+@Composable
+fun EventManagementScreen(event: OrgEventItem) {
+    val navigator = LocalNavigator.currentOrThrow
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        // Top bar
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Text(
+                "Мероприятие",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Spacer(Modifier.height(4.dp))
+
+            // Шапка: название + дата + площадка
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    event.label,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    event.time.formatEventTime(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (event.venueLabel != null) {
+                    Text(
+                        event.venueLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            // Статистика продаж (только если инвентарь настроен)
+            if (event.hasInventory) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Outlined.BarChart,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            "Статистика продаж",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Text(
+                        "${event.sold} / ${event.capacity} продано",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                    if (event.capacity > 0) {
+                        val pct = (event.sold * 100f / event.capacity).toInt()
+                        Text(
+                            "$pct% заполнено",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            // Кнопка «Настроить билеты» — только если инвентарь ещё не настроен
+            if (!event.hasInventory) {
+                Button(
+                    onClick = {
+                        navigator.push(
+                            com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(event.id, event.venueSpaceId)
+                        )
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Outlined.ConfirmationNumber, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text("Настроить билеты")
+                }
+            }
+
+            // Кнопка «Редактировать»
+            OutlinedButton(
+                onClick = {
+                    navigator.push(com.karrad.ticketsclient.ui.navigation.EditEventScreen(event.id))
+                },
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Outlined.Edit, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                Text("Редактировать")
+            }
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.ui.screen.org
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -205,6 +206,9 @@ fun OrgManagementScreen() {
                         items(state.events) { event ->
                             OrgEventRow(
                                 event = event,
+                                onClick = {
+                                    navigator.push(com.karrad.ticketsclient.ui.navigation.EventManagementScreen(event))
+                                },
                                 onSetupInventory = {
                                     navigator.push(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(event.id, event.venueSpaceId))
                                 }
@@ -432,6 +436,7 @@ fun OrgManagementScreen() {
 @Composable
 private fun OrgEventRow(
     event: OrgEventItem,
+    onClick: () -> Unit,
     onSetupInventory: () -> Unit
 ) {
     Row(
@@ -439,6 +444,7 @@ private fun OrgEventRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
+            .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeEventService.kt
@@ -9,6 +9,7 @@ import com.karrad.ticketsclient.data.api.dto.SeatMapDto
 import com.karrad.ticketsclient.data.api.dto.SeatRowDto
 import com.karrad.ticketsclient.data.api.dto.SeatSectionDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
+import com.karrad.ticketsclient.data.api.dto.UpdateEventRequest
 
 /**
  * Мок-реализация для разработки без бекенда.
@@ -83,6 +84,12 @@ class FakeEventService : EventService {
         )
 
     override suspend fun uploadCover(eventId: String, file: FileBytes) { /* no-op in mock */ }
+
+    override suspend fun updateEvent(eventId: String, request: UpdateEventRequest): EventDto =
+        allEvents.find { it.id == eventId }?.copy(
+            label = request.label ?: "",
+            description = request.description ?: ""
+        ) ?: getEvent(eventId)
 
     override suspend fun createGeneralAdmissionInventory(eventId: String, request: CreateGeneralAdmissionInventoryRequest) { /* no-op in mock */ }
 


### PR DESCRIPTION
## Summary

- **CreateEventScreen**: добавлен выбор зала/пространства (VenueSpace) после выбора площадки; `venueSpaceId` и `hasSeatMap` передаются на бек — исправляет критический баг с SEATED-инвентарём
- **OrgEventRow**: строки кликабельны → переход на `EventManagementScreen`
- **EventManagementScreen** (новый): заголовок события, статистика продаж (`sold/capacity`), кнопка «Настроить билеты» (если `!hasInventory`), кнопка «Редактировать»
- **EditEventScreen** (новый): форма редактирования названия, описания, даты/времени, возрастного рейтинга
- **Бек**: `PATCH /api/v1/events/{id}` + `UpdateEventUseCase`; `GenerateEventInventoryUseCase` теперь авто-вычисляет `minPrice` при создании инвентаря

## Test plan

- [ ] Создать ивент → выбрать площадку с залами → убедиться что dropdown VenueSpace появился → при SEATED-зале `hasSeatMap=true` уходит на бек
- [ ] Создать ивент без зала → форма проходит без ошибок
- [ ] Тап по ивенту в OrgManagementScreen → открывается EventManagementScreen
- [ ] EventManagementScreen: `!hasInventory` → кнопка «Настроить билеты»; `hasInventory` → статистика
- [ ] Кнопка «Редактировать» → EditEventScreen → изменить поля → сохранить → `GET /api/v1/events/{id}` обновлён
- [ ] После настройки инвентаря → `event.minPrice` заполнен

🤖 Generated with [Claude Code](https://claude.com/claude-code)