### PR TITLE
feat(#212,#213,#214): SpacePriceProfile UI, session times, sessions in feed

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceApiService.kt
@@ -1,9 +1,12 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateSpacePriceProfileRequest
 import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.SpacePriceProfileDto
 import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -23,4 +26,17 @@ class VenueSpaceApiService(
             contentType(ContentType.Application.Json)
             setBody(request)
         }.body()
+
+    override suspend fun listPriceProfiles(spaceId: String): List<SpacePriceProfileDto> =
+        httpClient.get("$baseUrl/api/v1/venue-spaces/$spaceId/price-profiles").body()
+
+    override suspend fun createPriceProfile(spaceId: String, request: CreateSpacePriceProfileRequest): SpacePriceProfileDto =
+        httpClient.post("$baseUrl/api/v1/venue-spaces/$spaceId/price-profiles") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }.body()
+
+    override suspend fun deletePriceProfile(spaceId: String, profileId: String) {
+        httpClient.delete("$baseUrl/api/v1/venue-spaces/$spaceId/price-profiles/$profileId")
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceService.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/VenueSpaceService.kt
@@ -1,9 +1,14 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateSpacePriceProfileRequest
 import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.SpacePriceProfileDto
 import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
 
 interface VenueSpaceService {
     suspend fun list(venueId: String): List<VenueSpaceDto>
     suspend fun add(venueId: String, request: CreateVenueSpaceRequest): VenueSpaceDto
+    suspend fun listPriceProfiles(spaceId: String): List<SpacePriceProfileDto>
+    suspend fun createPriceProfile(spaceId: String, request: CreateSpacePriceProfileRequest): SpacePriceProfileDto
+    suspend fun deletePriceProfile(spaceId: String, profileId: String)
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
@@ -31,7 +31,9 @@ data class EventDto(
     val ageRating: String? = null,
     val hasSeatMap: Boolean = false,   // true → выбор мест; false → типы билетов
     val organizationId: String? = null,
-    val salesClosedAt: String? = null
+    val salesClosedAt: String? = null,
+    val groupId: String? = null,
+    val sessionTimes: List<String> = emptyList()
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/ScannerDto.kt
@@ -11,7 +11,9 @@ data class OrgEventItem(
     val venueSpaceId: String? = null,
     val hasInventory: Boolean = false,
     val sold: Int = 0,
-    val capacity: Int = 0
+    val capacity: Int = 0,
+    val groupId: String? = null,
+    val sessionTimes: List<String> = emptyList()
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueApplicationDto.kt
@@ -36,7 +36,9 @@ data class CreateEventRequest(
     val imageUrl: String? = null,
     val ageRating: String? = null,
     val venueSpaceId: String? = null,
-    val hasSeatMap: Boolean? = null
+    val hasSeatMap: Boolean? = null,
+    val priceProfileId: String? = null,
+    val sessionTimes: List<String>? = null
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueSpaceDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/VenueSpaceDto.kt
@@ -16,3 +16,27 @@ data class CreateVenueSpaceRequest(
     val type: String,
     val capacity: Int
 )
+
+@Serializable
+data class SpacePriceProfileDto(
+    val id: String,
+    val venueSpaceId: String,
+    val label: String,
+    val mode: String,
+    val sectionPrices: List<SectionPriceDto> = emptyList(),
+    val ticketTypes: List<TicketTypeTemplateDto> = emptyList()
+)
+
+@Serializable
+data class SectionPriceDto(val sectionKey: String, val price: Int)
+
+@Serializable
+data class TicketTypeTemplateDto(val label: String, val price: Int, val quota: Int)
+
+@Serializable
+data class CreateSpacePriceProfileRequest(
+    val label: String,
+    val mode: String,
+    val sectionPrices: List<SectionPriceDto> = emptyList(),
+    val ticketTypes: List<TicketTypeTemplateDto> = emptyList()
+)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -150,6 +150,12 @@ data class SetupInventoryScreen(val eventId: String, val venueSpaceId: String? =
     override fun Content() = com.karrad.ticketsclient.ui.screen.org.SetupInventoryScreen(eventId, venueSpaceId)
 }
 
+// Venue space detail — price profile management
+data class VenueSpaceDetailScreen(val spaceId: String, val spaceLabel: String, val spaceType: String) : Screen {
+    @androidx.compose.runtime.Composable
+    override fun Content() = com.karrad.ticketsclient.ui.screen.org.VenueSpaceDetailScreen(spaceId, spaceLabel, spaceType)
+}
+
 // Layout template builder for SEATED venue spaces
 data class LayoutTemplateBuilderScreen(val venueSpaceId: String, val venueSpaceLabel: String) : Screen {
     @androidx.compose.runtime.Composable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -64,6 +64,8 @@ import com.karrad.ticketsclient.ui.screen.feed.EventImagePlaceholder
 import com.karrad.ticketsclient.ui.util.formatEventDate
 import com.karrad.ticketsclient.ui.util.formatEventDateFull
 import com.karrad.ticketsclient.ui.util.formatPrice
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import kotlinx.coroutines.launch
 
 @Composable
@@ -225,6 +227,42 @@ fun EventDetailScreen(eventId: String) {
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                    }
+                }
+
+                // Сеансы (если несколько)
+                if (event.sessionTimes.size > 1) {
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        "Сеансы",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        event.sessionTimes.forEach { sessionTime ->
+                            val isCurrentSession = sessionTime == event.time
+                            Box(
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(20.dp))
+                                    .background(
+                                        if (isCurrentSession) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.surfaceVariant
+                                    )
+                                    .padding(horizontal = 14.dp, vertical = 8.dp)
+                            ) {
+                                Text(
+                                    text = sessionTime.formatEventDate() ?: sessionTime,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = if (isCurrentSession) Color.White
+                                            else MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/EventCard.kt
@@ -38,6 +38,7 @@ import com.karrad.ticketsclient.crash.CrashReporter
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.ui.component.EventImage
+import com.karrad.ticketsclient.ui.util.formatEventDate
 import com.karrad.ticketsclient.ui.util.formatPrice
 import kotlinx.coroutines.launch
 
@@ -149,13 +150,24 @@ internal fun EventCard(
             overflow = TextOverflow.Ellipsis,
             lineHeight = 15.sp
         )
-        Text(
-            text = event.venueLabel ?: event.venueId.venueShort(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        if (event.sessionTimes.size > 1) {
+            val timesFormatted = event.sessionTimes.take(4).mapNotNull { it.formatEventDate() }.joinToString(" · ")
+            Text(
+                text = timesFormatted,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        } else {
+            Text(
+                text = event.venueLabel ?: event.venueId.venueShort(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventScreen.kt
@@ -17,12 +17,15 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.AddPhotoAlternate
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -33,6 +36,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -40,6 +44,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -51,7 +56,10 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.data.api.FileBytes
+import com.karrad.ticketsclient.data.api.dto.OrgEventItem
 import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.navigation.EventManagementScreen
+import com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen
 import com.karrad.ticketsclient.ui.util.rememberFilePicker
 import com.karrad.ticketsclient.ui.util.toImageBitmap
 
@@ -75,20 +83,36 @@ fun CreateEventScreen() {
     var selectedCategoryId by remember { mutableStateOf("") }
     var selectedCategoryLabel by remember { mutableStateOf("Выберите категорию") }
     var selectedAgeRating by remember { mutableStateOf("") }
-    var dateText by remember { mutableStateOf("") }
-    var timeText by remember { mutableStateOf("") }
     var venueMenuExpanded by remember { mutableStateOf(false) }
     var categoryMenuExpanded by remember { mutableStateOf(false) }
     var spaceMenuExpanded by remember { mutableStateOf(false) }
+    var profileMenuExpanded by remember { mutableStateOf(false) }
     var selectedSpaceId by remember { mutableStateOf<String?>(null) }
     var selectedSpaceLabel by remember { mutableStateOf("Выберите зал / пространство") }
-    var selectedSpaceType by remember { mutableStateOf("ADMISSION") }
+    var selectedPriceProfileId by remember { mutableStateOf<String?>(null) }
+    var selectedPriceProfileLabel by remember { mutableStateOf("Выберите ценовой профиль") }
+    // Session times: list of "YYYY-MM-DD" to "HH:MM" pairs
+    val sessionDates = remember { mutableStateListOf("") }
+    val sessionTimes = remember { mutableStateListOf("") }
     var coverFile by remember { mutableStateOf<FileBytes?>(null) }
     val pickCover = rememberFilePicker { files -> coverFile = files.firstOrNull() }
 
-    LaunchedEffect(state.createdEventId) {
-        val eventId = state.createdEventId ?: return@LaunchedEffect
-        navigator.replace(com.karrad.ticketsclient.ui.navigation.SetupInventoryScreen(eventId, selectedSpaceId))
+    LaunchedEffect(state.createdEvent) {
+        val event = state.createdEvent ?: return@LaunchedEffect
+        if (selectedPriceProfileId != null) {
+            navigator.replace(EventManagementScreen(
+                OrgEventItem(
+                    id = event.id,
+                    label = event.label,
+                    time = event.time,
+                    venueLabel = event.venueLabel,
+                    venueSpaceId = selectedSpaceId,
+                    hasInventory = true
+                )
+            ))
+        } else {
+            navigator.replace(SetupInventoryScreen(event.id, selectedSpaceId))
+        }
     }
 
     Column(
@@ -206,7 +230,8 @@ fun CreateEventScreen() {
                                     // Сбросить выбор зала и загрузить новые
                                     selectedSpaceId = null
                                     selectedSpaceLabel = "Выберите зал / пространство"
-                                    selectedSpaceType = "ADMISSION"
+                                    selectedPriceProfileId = null
+                                    selectedPriceProfileLabel = "Выберите ценовой профиль"
                                     vm.onVenueSelected(venue.id)
                                 }
                             )
@@ -249,7 +274,8 @@ fun CreateEventScreen() {
                                 onClick = {
                                     selectedSpaceId = null
                                     selectedSpaceLabel = "Без зала"
-                                    selectedSpaceType = "ADMISSION"
+                                    selectedPriceProfileId = null
+                                    selectedPriceProfileLabel = "Выберите ценовой профиль"
                                     spaceMenuExpanded = false
                                 }
                             )
@@ -259,7 +285,7 @@ fun CreateEventScreen() {
                                         Column {
                                             Text(space.label)
                                             Text(
-                                                space.type,
+                                                if (space.type == "SEATED") "С местами" else "Партер",
                                                 style = MaterialTheme.typography.labelSmall,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
@@ -268,8 +294,65 @@ fun CreateEventScreen() {
                                     onClick = {
                                         selectedSpaceId = space.id
                                         selectedSpaceLabel = space.label
-                                        selectedSpaceType = space.type
+                                        selectedPriceProfileId = null
+                                        selectedPriceProfileLabel = "Выберите ценовой профиль"
                                         spaceMenuExpanded = false
+                                        vm.onSpaceSelected(space.id)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Price profile selector — показывается если выбран зал
+                if (selectedSpaceId != null && (state.priceProfiles.isNotEmpty() || state.priceProfilesLoading)) {
+                    Box {
+                        OutlinedButton(
+                            onClick = { profileMenuExpanded = true },
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled = !state.priceProfilesLoading
+                        ) {
+                            if (state.priceProfilesLoading) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp).padding(end = 8.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            }
+                            Text(
+                                if (state.priceProfilesLoading) "Загрузка профилей..." else selectedPriceProfileLabel,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = profileMenuExpanded,
+                            onDismissRequest = { profileMenuExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Без профиля", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                                onClick = {
+                                    selectedPriceProfileId = null
+                                    selectedPriceProfileLabel = "Без профиля"
+                                    profileMenuExpanded = false
+                                }
+                            )
+                            state.priceProfiles.forEach { profile ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Column {
+                                            Text(profile.label)
+                                            Text(
+                                                if (profile.mode == "SEATED") "С местами" else "Без рассадки",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        selectedPriceProfileId = profile.id
+                                        selectedPriceProfileLabel = profile.label
+                                        profileMenuExpanded = false
                                     }
                                 )
                             }
@@ -309,27 +392,68 @@ fun CreateEventScreen() {
                     onSelect = { selectedAgeRating = it }
                 )
 
-                // Date input
-                OutlinedTextField(
-                    value = dateText,
-                    onValueChange = { dateText = it },
-                    label = { Text("Дата") },
-                    placeholder = { Text("2025-12-31") },
-                    singleLine = true,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                // Time input
-                OutlinedTextField(
-                    value = timeText,
-                    onValueChange = { timeText = it },
-                    label = { Text("Время (UTC)") },
-                    placeholder = { Text("18:00") },
-                    singleLine = true,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth()
-                )
+                // Session times
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        "Сеансы",
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                        modifier = Modifier.weight(1f)
+                    )
+                    if (sessionDates.size < 10) {
+                        TextButton(onClick = {
+                            sessionDates.add("")
+                            sessionTimes.add("")
+                        }) {
+                            Icon(Icons.Outlined.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                            Spacer(Modifier.width(4.dp))
+                            Text("Добавить")
+                        }
+                    }
+                }
+                sessionDates.forEachIndexed { index, date ->
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        OutlinedTextField(
+                            value = date,
+                            onValueChange = { sessionDates[index] = it },
+                            label = { Text("Дата ${index + 1}") },
+                            placeholder = { Text("2026-06-01") },
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier.weight(1.4f)
+                        )
+                        OutlinedTextField(
+                            value = sessionTimes[index],
+                            onValueChange = { sessionTimes[index] = it },
+                            label = { Text("Время (UTC)") },
+                            placeholder = { Text("18:00") },
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier.weight(1f)
+                        )
+                        if (sessionDates.size > 1) {
+                            IconButton(
+                                onClick = {
+                                    sessionDates.removeAt(index)
+                                    sessionTimes.removeAt(index)
+                                },
+                                modifier = Modifier.size(36.dp)
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Delete,
+                                    contentDescription = "Удалить сеанс",
+                                    modifier = Modifier.size(20.dp),
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+                }
 
                 if (state.error != null) {
                     Text(
@@ -339,22 +463,28 @@ fun CreateEventScreen() {
                     )
                 }
 
+                val dateRegex = Regex("\\d{4}-\\d{2}-\\d{2}")
+                val timeRegex = Regex("\\d{2}:\\d{2}")
+                val allSessionsValid = sessionDates.indices.all { i ->
+                    sessionDates[i].matches(dateRegex) && sessionTimes[i].matches(timeRegex)
+                }
                 val canSubmit = label.isNotBlank() && description.isNotBlank() &&
                     selectedVenueId.isNotBlank() && selectedCategoryId.isNotBlank() &&
                     selectedAgeRating.isNotBlank() &&
-                    dateText.matches(Regex("\\d{4}-\\d{2}-\\d{2}")) &&
-                    timeText.matches(Regex("\\d{2}:\\d{2}")) &&
+                    allSessionsValid &&
                     coverFile != null &&
                     !state.isSubmitting
 
                 Button(
                     onClick = {
-                        val isoTime = "${dateText}T${timeText}:00Z"
+                        val isoTimes = sessionDates.indices.map { i ->
+                            "${sessionDates[i]}T${sessionTimes[i]}:00Z"
+                        }
                         vm.submit(
                             label, description, selectedVenueId, selectedCategoryId,
-                            selectedAgeRating, isoTime, coverFile!!,
+                            selectedAgeRating, isoTimes, coverFile!!,
                             venueSpaceId = selectedSpaceId,
-                            hasSeatMap = selectedSpaceType == "SEATED"
+                            priceProfileId = selectedPriceProfileId
                         )
                     },
                     enabled = canSubmit,

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
@@ -9,6 +9,8 @@ import com.karrad.ticketsclient.data.api.OrgMemberService
 import com.karrad.ticketsclient.data.api.VenueSpaceService
 import com.karrad.ticketsclient.data.api.dto.CategoryDto
 import com.karrad.ticketsclient.data.api.dto.CreateEventRequest
+import com.karrad.ticketsclient.data.api.dto.EventDto
+import com.karrad.ticketsclient.data.api.dto.SpacePriceProfileDto
 import com.karrad.ticketsclient.data.api.dto.VenueDto
 import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
 import com.karrad.ticketsclient.data.api.GeoService
@@ -22,10 +24,12 @@ data class CreateEventState(
     val categories: List<CategoryDto> = emptyList(),
     val spaces: List<VenueSpaceDto> = emptyList(),
     val spacesLoading: Boolean = false,
+    val priceProfiles: List<SpacePriceProfileDto> = emptyList(),
+    val priceProfilesLoading: Boolean = false,
     val isLoading: Boolean = true,
     val isSubmitting: Boolean = false,
     val error: String? = null,
-    val createdEventId: String? = null
+    val createdEvent: EventDto? = null
 )
 
 class CreateEventViewModel(
@@ -56,10 +60,18 @@ class CreateEventViewModel(
     }
 
     fun onVenueSelected(venueId: String) {
-        _state.value = _state.value.copy(spacesLoading = true, spaces = emptyList())
+        _state.value = _state.value.copy(spacesLoading = true, spaces = emptyList(), priceProfiles = emptyList())
         viewModelScope.launch {
             val spaces = runCatching { venueSpaceService.list(venueId) }.getOrDefault(emptyList())
             _state.value = _state.value.copy(spaces = spaces, spacesLoading = false)
+        }
+    }
+
+    fun onSpaceSelected(spaceId: String) {
+        _state.value = _state.value.copy(priceProfilesLoading = true, priceProfiles = emptyList())
+        viewModelScope.launch {
+            val profiles = runCatching { venueSpaceService.listPriceProfiles(spaceId) }.getOrDefault(emptyList())
+            _state.value = _state.value.copy(priceProfiles = profiles, priceProfilesLoading = false)
         }
     }
 
@@ -69,10 +81,10 @@ class CreateEventViewModel(
         venueId: String,
         categoryId: String,
         ageRating: String,
-        isoTime: String,
+        sessionTimes: List<String>,
         coverFile: FileBytes,
         venueSpaceId: String?,
-        hasSeatMap: Boolean
+        priceProfileId: String?
     ) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isSubmitting = true, error = null)
@@ -83,17 +95,19 @@ class CreateEventViewModel(
                         description = description,
                         venueId = venueId,
                         categoryId = categoryId,
-                        time = isoTime,
+                        time = sessionTimes.firstOrNull() ?: "",
                         ageRating = ageRating,
                         venueSpaceId = venueSpaceId,
-                        hasSeatMap = hasSeatMap
+                        hasSeatMap = priceProfileId != null,
+                        priceProfileId = priceProfileId,
+                        sessionTimes = if (sessionTimes.size > 1) sessionTimes else null
                     )
                 )
                 val coverError = runCatching { eventService.uploadCover(event.id, coverFile) }
                     .exceptionOrNull()?.also { CrashReporter.log(it) }
                 _state.value = _state.value.copy(
                     isSubmitting = false,
-                    createdEventId = event.id,
+                    createdEvent = event,
                     error = if (coverError != null) "Мероприятие создано, но обложка не загружена" else null
                 )
             } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpaceDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpaceDetailScreen.kt
@@ -1,0 +1,416 @@
+package com.karrad.ticketsclient.ui.screen.org
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.dto.CreateSpacePriceProfileRequest
+import com.karrad.ticketsclient.data.api.dto.SectionPriceDto
+import com.karrad.ticketsclient.data.api.dto.SpacePriceProfileDto
+import com.karrad.ticketsclient.data.api.dto.TicketTypeTemplateDto
+import com.karrad.ticketsclient.di.AppContainer
+import com.karrad.ticketsclient.ui.navigation.LayoutTemplateBuilderScreen
+import kotlinx.coroutines.launch
+
+@Composable
+fun VenueSpaceDetailScreen(spaceId: String, spaceLabel: String, spaceType: String) {
+    val navigator = LocalNavigator.currentOrThrow
+    val scope = rememberCoroutineScope()
+    val profiles = remember { mutableStateListOf<SpacePriceProfileDto>() }
+    var loading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var deleteTarget by remember { mutableStateOf<SpacePriceProfileDto?>(null) }
+
+    LaunchedEffect(spaceId) {
+        loading = true
+        runCatching { AppContainer.venueSpaceService.listPriceProfiles(spaceId) }
+            .onSuccess { profiles.addAll(it) }
+            .onFailure { error = it.message }
+        loading = false
+    }
+
+    if (showAddDialog) {
+        AddPriceProfileDialog(
+            spaceType = spaceType,
+            onDismiss = { showAddDialog = false },
+            onConfirm = { request ->
+                showAddDialog = false
+                scope.launch {
+                    runCatching { AppContainer.venueSpaceService.createPriceProfile(spaceId, request) }
+                        .onSuccess { profiles.add(it) }
+                        .onFailure { CrashReporter.log(it) }
+                }
+            }
+        )
+    }
+
+    deleteTarget?.let { profile ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("Удалить профиль?") },
+            text = { Text("Профиль «${profile.label}» будет удалён.") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val target = profile
+                        deleteTarget = null
+                        scope.launch {
+                            runCatching { AppContainer.venueSpaceService.deletePriceProfile(spaceId, target.id) }
+                                .onSuccess { profiles.remove(target) }
+                                .onFailure { CrashReporter.log(it) }
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Удалить") }
+            },
+            dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("Отмена") } }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navigator.pop() }) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Назад")
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    spaceLabel,
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    if (spaceType == "SEATED") "С местами" else "Партер",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (spaceType == "SEATED") {
+                OutlinedButton(
+                    onClick = { navigator.push(LayoutTemplateBuilderScreen(spaceId, spaceLabel)) },
+                    modifier = Modifier.padding(end = 8.dp)
+                ) { Text("Схема мест") }
+            }
+        }
+
+        when {
+            loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Ошибка: $error", color = MaterialTheme.colorScheme.error)
+            }
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            "Ценовые профили",
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                            modifier = Modifier.weight(1f)
+                        )
+                        IconButton(onClick = { showAddDialog = true }) {
+                            Icon(Icons.Outlined.Add, contentDescription = "Добавить профиль")
+                        }
+                    }
+                }
+
+                if (profiles.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                                .padding(24.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                "Нет ценовых профилей.\nНажмите «+» чтобы добавить.",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+
+                items(profiles) { profile ->
+                    PriceProfileRow(profile, onDelete = { deleteTarget = profile })
+                }
+
+                item { Spacer(Modifier.height(16.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PriceProfileRow(profile: SpacePriceProfileDto, onDelete: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(profile.label, style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold))
+            Spacer(Modifier.height(2.dp))
+            val modeLabel = if (profile.mode == "SEATED") "С местами" else "Без рассадки"
+            val detailLabel = when (profile.mode) {
+                "SEATED" -> "${profile.sectionPrices.size} зон"
+                else -> "${profile.ticketTypes.size} типов билетов"
+            }
+            Text(
+                "$modeLabel · $detailLabel",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Outlined.Delete,
+                contentDescription = "Удалить",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}
+
+private data class SectionPriceEntry(var key: String = "", var price: String = "")
+private data class TicketTypeEntry(var label: String = "", var price: String = "", var quota: String = "")
+
+@Composable
+private fun AddPriceProfileDialog(
+    spaceType: String,
+    onDismiss: () -> Unit,
+    onConfirm: (CreateSpacePriceProfileRequest) -> Unit
+) {
+    var profileLabel by remember { mutableStateOf("") }
+    var mode by remember { mutableStateOf(spaceType) }
+    var modeMenuExpanded by remember { mutableStateOf(false) }
+    val sectionEntries = remember { mutableStateListOf(SectionPriceEntry()) }
+    val ticketEntries = remember { mutableStateListOf(TicketTypeEntry()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Добавить ценовой профиль") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = profileLabel,
+                    onValueChange = { profileLabel = it },
+                    label = { Text("Название профиля") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp)
+                )
+
+                // Mode selector
+                Box {
+                    OutlinedTextField(
+                        value = if (mode == "SEATED") "С местами" else "Без рассадки",
+                        onValueChange = {},
+                        label = { Text("Режим") },
+                        modifier = Modifier.fillMaxWidth(),
+                        readOnly = true,
+                        singleLine = true,
+                        shape = RoundedCornerShape(12.dp),
+                        trailingIcon = {
+                            TextButton(onClick = { modeMenuExpanded = true }) { Text("Изм.") }
+                        }
+                    )
+                    DropdownMenu(
+                        expanded = modeMenuExpanded,
+                        onDismissRequest = { modeMenuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("С местами (SEATED)") },
+                            onClick = { mode = "SEATED"; modeMenuExpanded = false }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Без рассадки (GA)") },
+                            onClick = { mode = "GENERAL_ADMISSION"; modeMenuExpanded = false }
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+
+                if (mode == "SEATED") {
+                    Text("Цены по секциям", style = MaterialTheme.typography.labelMedium)
+                    sectionEntries.forEachIndexed { index, entry ->
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                            OutlinedTextField(
+                                value = entry.key,
+                                onValueChange = { sectionEntries[index] = entry.copy(key = it) },
+                                label = { Text("Секция") },
+                                modifier = Modifier.weight(1f),
+                                singleLine = true,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            OutlinedTextField(
+                                value = entry.price,
+                                onValueChange = { if (it.all(Char::isDigit)) sectionEntries[index] = entry.copy(price = it) },
+                                label = { Text("₽") },
+                                modifier = Modifier.weight(1f),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            if (sectionEntries.size > 1) {
+                                IconButton(onClick = { sectionEntries.removeAt(index) }, modifier = Modifier.size(36.dp)) {
+                                    Icon(Icons.Outlined.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                }
+                            }
+                        }
+                    }
+                    TextButton(onClick = { sectionEntries.add(SectionPriceEntry()) }) {
+                        Icon(Icons.Outlined.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Text(" Добавить секцию")
+                    }
+                } else {
+                    Text("Типы билетов", style = MaterialTheme.typography.labelMedium)
+                    ticketEntries.forEachIndexed { index, entry ->
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            OutlinedTextField(
+                                value = entry.label,
+                                onValueChange = { ticketEntries[index] = entry.copy(label = it) },
+                                label = { Text("Название") },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                                OutlinedTextField(
+                                    value = entry.price,
+                                    onValueChange = { if (it.all(Char::isDigit)) ticketEntries[index] = entry.copy(price = it) },
+                                    label = { Text("Цена ₽") },
+                                    modifier = Modifier.weight(1f),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                OutlinedTextField(
+                                    value = entry.quota,
+                                    onValueChange = { if (it.all(Char::isDigit)) ticketEntries[index] = entry.copy(quota = it) },
+                                    label = { Text("Кол-во") },
+                                    modifier = Modifier.weight(1f),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                if (ticketEntries.size > 1) {
+                                    IconButton(onClick = { ticketEntries.removeAt(index) }, modifier = Modifier.size(36.dp)) {
+                                        Icon(Icons.Outlined.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    }
+                                }
+                            }
+                        }
+                        if (index < ticketEntries.size - 1) HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    }
+                    TextButton(onClick = { ticketEntries.add(TicketTypeEntry()) }) {
+                        Icon(Icons.Outlined.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Text(" Добавить тип")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            val canConfirm = profileLabel.isNotBlank() && if (mode == "SEATED")
+                sectionEntries.all { it.key.isNotBlank() && it.price.isNotBlank() }
+            else
+                ticketEntries.all { it.label.isNotBlank() && it.price.isNotBlank() && it.quota.isNotBlank() }
+
+            Button(
+                onClick = {
+                    val request = if (mode == "SEATED") {
+                        CreateSpacePriceProfileRequest(
+                            label = profileLabel.trim(),
+                            mode = "SEATED",
+                            sectionPrices = sectionEntries.map { SectionPriceDto(it.key.trim(), it.price.toInt()) }
+                        )
+                    } else {
+                        CreateSpacePriceProfileRequest(
+                            label = profileLabel.trim(),
+                            mode = "GENERAL_ADMISSION",
+                            ticketTypes = ticketEntries.map {
+                                TicketTypeTemplateDto(it.label.trim(), it.price.toInt(), it.quota.toInt())
+                            }
+                        )
+                    }
+                    onConfirm(request)
+                },
+                enabled = canConfirm
+            ) { Text("Создать") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Отмена") } }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/VenueSpacesScreen.kt
@@ -1,6 +1,7 @@
 package com.karrad.ticketsclient.ui.screen.org
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,6 +47,7 @@ import androidx.compose.ui.Alignment
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.ui.navigation.LayoutTemplateBuilderScreen
+import com.karrad.ticketsclient.ui.navigation.VenueSpaceDetailScreen
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
@@ -166,6 +168,7 @@ private fun VenueSpaceRow(space: VenueSpaceDto, navigator: cafe.adriel.voyager.n
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
+            .clickable { navigator.push(VenueSpaceDetailScreen(space.id, space.label, space.type)) }
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueSpaceService.kt
+++ b/composeApp/src/mock/kotlin/com/karrad/ticketsclient/data/api/FakeVenueSpaceService.kt
@@ -1,12 +1,15 @@
 package com.karrad.ticketsclient.data.api
 
+import com.karrad.ticketsclient.data.api.dto.CreateSpacePriceProfileRequest
 import com.karrad.ticketsclient.data.api.dto.CreateVenueSpaceRequest
+import com.karrad.ticketsclient.data.api.dto.SpacePriceProfileDto
 import com.karrad.ticketsclient.data.api.dto.VenueSpaceDto
 import java.util.UUID
 
 class FakeVenueSpaceService : VenueSpaceService {
 
     private val storage = mutableMapOf<String, MutableList<VenueSpaceDto>>()
+    private val profileStorage = mutableMapOf<String, MutableList<SpacePriceProfileDto>>()
 
     override suspend fun list(venueId: String): List<VenueSpaceDto> =
         storage[venueId] ?: emptyList()
@@ -20,5 +23,25 @@ class FakeVenueSpaceService : VenueSpaceService {
         )
         storage.getOrPut(venueId) { mutableListOf() }.add(space)
         return space
+    }
+
+    override suspend fun listPriceProfiles(spaceId: String): List<SpacePriceProfileDto> =
+        profileStorage[spaceId] ?: emptyList()
+
+    override suspend fun createPriceProfile(spaceId: String, request: CreateSpacePriceProfileRequest): SpacePriceProfileDto {
+        val profile = SpacePriceProfileDto(
+            id = UUID.randomUUID().toString(),
+            venueSpaceId = spaceId,
+            label = request.label,
+            mode = request.mode,
+            sectionPrices = request.sectionPrices,
+            ticketTypes = request.ticketTypes
+        )
+        profileStorage.getOrPut(spaceId) { mutableListOf() }.add(profile)
+        return profile
+    }
+
+    override suspend fun deletePriceProfile(spaceId: String, profileId: String) {
+        profileStorage[spaceId]?.removeIf { it.id == profileId }
     }
 }


### PR DESCRIPTION
## Summary

- **#212 Управление ценовыми профилями**: строки в `VenueSpacesScreen` стали кликабельными → новый `VenueSpaceDetailScreen` со списком профилей и диалогом создания. Диалог поддерживает SEATED (секции + цены) и GA (типы билетов + квота). Удаление с подтверждением.
- **#213 Новый флоу создания ивента**: после выбора зала подгружаются ценовые профили; вместо одной даты — список сеансов (до 10, кнопки «+» / «−»); при передаче `priceProfileId` инвентарь генерируется на беке автоматически — навигация ведёт в `EventManagementScreen`; без профиля → `SetupInventoryScreen`.
- **#214 Сеансы в ленте и на странице ивента**: `EventCard` показывает все времена группы сеансов вместо локации; `EventDetailScreen` отображает горизонтальный scroll из чипов сеансов (текущий подсвечен primary-цветом).

## Новые/изменённые файлы
- `VenueSpaceDetailScreen.kt` — новый экран управления профилями
- `CreateEventScreen.kt` / `CreateEventViewModel.kt` — price profile picker + session times list
- `EventCard.kt` — показ session times
- `EventDetailScreen.kt` — чипы сеансов
- DTOs: `SpacePriceProfileDto`, `SectionPriceDto`, `TicketTypeTemplateDto`, `CreateSpacePriceProfileRequest`; `EventDto`/`OrgEventItem` + `groupId`/`sessionTimes`; `CreateEventRequest` + `priceProfileId`/`sessionTimes`

## Test plan
- [ ] VenueSpacesScreen → тап на зал → открывается VenueSpaceDetailScreen
- [ ] Создать SEATED-профиль с секциями → отображается в списке
- [ ] Создать GA-профиль с типами билетов → отображается в списке
- [ ] Удалить профиль → исчезает из списка
- [ ] CreateEventScreen: выбрать зал → подгружаются профили
- [ ] Добавить 3 сеанса → 3 отдельных поля дата/время
- [ ] Создать ивент с профилем → попасть в EventManagementScreen
- [ ] В ленте карточка группы показывает все времена сеансов
- [ ] EventDetailScreen для группового ивента показывает чипы сеансов

Closes #212, #213, #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)