### PR TITLE
fix(#211): показывать «Билеты ещё не поступили» при отсутствии инвентаря

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -293,43 +293,58 @@ fun EventDetailScreen(eventId: String) {
             shadowElevation = 8.dp,
             color = MaterialTheme.colorScheme.surface
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-                    .height(52.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(MaterialTheme.colorScheme.primary)
-                    .clickable {
-                        if (event.hasSeatMap) {
-                            navigator.push(SeatMapScreen(event.id))
-                        } else {
-                            navigator.push(TicketTypeScreen(event.id))
-                        }
-                    },
-                contentAlignment = Alignment.Center
-            ) {
-                Row(
+            if (event.minPrice != null) {
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 20.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .height(52.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(MaterialTheme.colorScheme.primary)
+                        .clickable {
+                            if (event.hasSeatMap) {
+                                navigator.push(SeatMapScreen(event.id))
+                            } else {
+                                navigator.push(TicketTypeScreen(event.id))
+                            }
+                        },
+                    contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        "Выбрать",
-                        color = Color.White,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 16.sp
-                    )
-                    event.minPrice?.let { price ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         Text(
-                            "от ${price.formatPrice()} ₽",
+                            "Выбрать",
+                            color = Color.White,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.sp
+                        )
+                        Text(
+                            "от ${event.minPrice.formatPrice()} ₽",
                             color = Color.White.copy(alpha = 0.9f),
                             fontWeight = FontWeight.Medium,
                             fontSize = 14.sp
                         )
                     }
+                }
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .height(52.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "Билеты ещё не поступили в продажу",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp
+                    )
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/seatmap/SeatMapScreen.kt
@@ -58,6 +58,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import androidx.compose.runtime.LaunchedEffect
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.ApiException
 import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.SeatKeyRequestDto
@@ -95,10 +96,18 @@ fun SeatMapScreen(eventId: String) {
     var event by remember { mutableStateOf<EventDto?>(null) }
     var seatMap by remember { mutableStateOf<SeatMapDto?>(null) }
     var isLoading by remember { mutableStateOf(true) }
+    var noInventory by remember { mutableStateOf(false) }
+    var loadError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(eventId) {
         event = try { AppContainer.eventService.getEvent(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
-        seatMap = try { AppContainer.eventService.getSeatMap(eventId) } catch (e: Exception) { CrashReporter.log(e); null }
+        try {
+            seatMap = AppContainer.eventService.getSeatMap(eventId)
+        } catch (e: ApiException) {
+            if (e.statusCode == 404) noInventory = true else { CrashReporter.log(e); loadError = e.message }
+        } catch (e: Exception) {
+            CrashReporter.log(e); loadError = e.message
+        }
         isLoading = false
     }
 
@@ -162,38 +171,59 @@ fun SeatMapScreen(eventId: String) {
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .clipToBounds()
-                    .transformable(state = transformState)
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer(
-                            scaleX = scale, scaleY = scale,
-                            translationX = offset.x, translationY = offset.y
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    SeatGrid(
-                        seats = allSeats,
-                        selected = selectedSeats,
-                        onSeatClick = { seat ->
-                            if (!seat.available) return@SeatGrid
-                            selectedSeats = if (seat in selectedSeats) selectedSeats - seat
-                            else selectedSeats + seat
+                when {
+                    noInventory -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            "Билеты ещё не поступили в продажу",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    loadError != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            "Не удалось загрузить схему зала",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                    else -> Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clipToBounds()
+                            .transformable(state = transformState)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .graphicsLayer(
+                                    scaleX = scale, scaleY = scale,
+                                    translationX = offset.x, translationY = offset.y
+                                ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            SeatGrid(
+                                seats = allSeats,
+                                selected = selectedSeats,
+                                onSeatClick = { seat ->
+                                    if (!seat.available) return@SeatGrid
+                                    selectedSeats = if (seat in selectedSeats) selectedSeats - seat
+                                    else selectedSeats + seat
+                                }
+                            )
                         }
-                    )
-                }
 
-                // ─── +/- кнопки ──────────────────────────────────────────────
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    ZoomButton("+") { scale = (scale * 1.2f).coerceAtMost(3f) }
-                    ZoomButton("−") { scale = (scale / 1.2f).coerceAtLeast(0.6f) }
+                        // ─── +/- кнопки ──────────────────────────────────────
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .padding(end = 12.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            ZoomButton("+") { scale = (scale * 1.2f).coerceAtMost(3f) }
+                            ZoomButton("−") { scale = (scale / 1.2f).coerceAtLeast(0.6f) }
+                        }
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/tickettype/TicketTypeScreen.kt
@@ -49,6 +49,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.karrad.ticketsclient.AppSession
 import com.karrad.ticketsclient.crash.CrashReporter
+import com.karrad.ticketsclient.data.api.ApiException
 import com.karrad.ticketsclient.data.api.dto.AdmissionInventoryItemRequestDto
 import com.karrad.ticketsclient.data.api.dto.CreateOrderRequestDto
 import com.karrad.ticketsclient.data.api.dto.TicketTypeDto
@@ -77,6 +78,9 @@ fun TicketTypeScreen(eventId: String) {
         try {
             ticketTypes = AppContainer.eventService.getTicketTypes(eventId)
             ticketTypes.forEach { quantities[it.id] = 0 }
+        } catch (e: ApiException) {
+            if (e.statusCode == 404) loadError = "Билеты ещё не поступили в продажу"
+            else { CrashReporter.log(e); loadError = e.message ?: "Не удалось загрузить типы билетов" }
         } catch (e: Exception) {
             CrashReporter.log(e)
             loadError = e.message ?: "Не удалось загрузить типы билетов"


### PR DESCRIPTION
## Summary
- `SeatMapScreen`: 404 → «Билеты ещё не поступили в продажу» вместо «Схема мест недоступна»
- `TicketTypeScreen`: аналогично различаем 404 и сетевые ошибки
- `EventDetailScreen`: кнопка «Выбрать» скрыта когда `minPrice == null`; вместо неё — информационный текст

Closes #211

## Test plan
- [ ] Открыть мероприятие без инвентаря → кнопки «Выбрать» не видно, текст «Билеты ещё не поступили в продажу»
- [ ] Нажать «Схема мест» у мероприятия без инвентаря → информационный текст, а не ошибка
- [ ] Нажать «Типы билетов» у мероприятия без инвентаря → аналогично
- [ ] При реальной сетевой ошибке → по-прежнему показывается сообщение об ошибке

🤖 Generated with [Claude Code](https://claude.com/claude-code)