### PR TITLE
fix: кликабельные сеансы в EventDetailScreen + sessionEventIds

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/data/api/dto/DiscoveryFeedDto.kt
@@ -33,7 +33,8 @@ data class EventDto(
     val organizationId: String? = null,
     val salesClosedAt: String? = null,
     val groupId: String? = null,
-    val sessionTimes: List<String> = emptyList()
+    val sessionTimes: List<String> = emptyList(),
+    val sessionEventIds: List<String> = emptyList()
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -244,14 +244,20 @@ fun EventDetailScreen(eventId: String) {
                             .horizontalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        event.sessionTimes.forEach { sessionTime ->
-                            val isCurrentSession = sessionTime == event.time
+                        event.sessionTimes.forEachIndexed { index, sessionTime ->
+                            val sessionId = event.sessionEventIds.getOrNull(index)
+                            val isCurrentSession = sessionId == event.id || (sessionId == null && sessionTime == event.time)
                             Box(
                                 modifier = Modifier
                                     .clip(RoundedCornerShape(20.dp))
                                     .background(
                                         if (isCurrentSession) MaterialTheme.colorScheme.primary
                                         else MaterialTheme.colorScheme.surfaceVariant
+                                    )
+                                    .then(
+                                        if (!isCurrentSession && sessionId != null)
+                                            Modifier.clickable { navigator.push(com.karrad.ticketsclient.ui.navigation.EventDetailScreen(sessionId)) }
+                                        else Modifier
                                     )
                                     .padding(horizontal = 14.dp, vertical = 8.dp)
                             ) {


### PR DESCRIPTION
## Проблема

При просмотре сгруппированной карточки (несколько сеансов) пользователь видел чипы с временами сеансов, но:
- Чипы не были кликабельными — невозможно выбрать конкретный сеанс
- Кнопка «Выбрать» всегда использовала `event.id` (первый/ближайший сеанс), игнорируя выбор пользователя

## Изменения

- `EventDto`: добавлено поле `sessionEventIds: List<String>` (parallel to `sessionTimes`)
- `EventDetailScreen`: чипы сеансов теперь кликабельны — тап открывает `EventDetailScreen(sessionEventId)` для этого конкретного сеанса; текущий сеанс остаётся некликабельным

## Связанный PR бекенда

https://github.com/karrad1201/ticketsbackend/pull/334 — бекенд теперь заполняет `sessionEventIds` в `deduplicateGroups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)