### PR TITLE
feat: share button + iOS APNs push registration

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/push/PushHooks.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/push/PushHooks.android.kt
@@ -1,0 +1,4 @@
+package com.karrad.ticketsclient.push
+
+// Android token registration is handled by MyFirebaseMessagingService.onNewToken
+actual fun onAfterLogin() = Unit

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.android.kt
@@ -1,0 +1,20 @@
+package com.karrad.ticketsclient.ui.util
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberShareLauncher(text: String): () -> Unit {
+    val context = LocalContext.current
+    return remember(text) {
+        {
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, text)
+            }
+            context.startActivity(Intent.createChooser(intent, null))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -7,6 +7,7 @@ import com.karrad.ticketsclient.data.api.dto.EventDto
 import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.store.SessionSnapshot
 import com.karrad.ticketsclient.data.store.TokenStore
+import com.karrad.ticketsclient.push.onAfterLogin
 
 /**
  * In-memory app session. Holds auth state and short-lived navigation data.
@@ -81,6 +82,7 @@ object AppSession {
         this.userAvatarUrl = avatarUrl
         this.userInterests = interests
         TokenStore.save(SessionSnapshot(token, userId, fullName, phone ?: "", role))
+        onAfterLogin()
     }
 
     /** Восстановить сессию из персистентного хранилища (вызывать при старте приложения). */

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/push/PushHooks.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/push/PushHooks.kt
@@ -1,0 +1,3 @@
+package com.karrad.ticketsclient.push
+
+expect fun onAfterLogin()

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -77,6 +77,8 @@ import com.karrad.ticketsclient.ui.theme.FreeGreen
 import com.karrad.ticketsclient.ui.util.formatEventDate
 import com.karrad.ticketsclient.ui.util.formatSessionsCompact
 import com.karrad.ticketsclient.ui.util.formatPrice
+import com.karrad.ticketsclient.ui.util.rememberShareLauncher
+import androidx.compose.material.icons.outlined.Share
 import kotlinx.coroutines.launch
 
 @Composable
@@ -109,6 +111,13 @@ fun EventDetailScreen(eventId: String) {
 
     val scrollState = rememberScrollState()
     val parallaxOffset = scrollState.value * 0.4f
+
+    val shareText = buildString {
+        append("«${event.label}»")
+        event.time.formatEventDate()?.let { append(" — $it") }
+        (event.venueLabel ?: event.venueId).let { append(", $it") }
+    }
+    val share = rememberShareLauncher(shareText)
 
     Box(
         modifier = Modifier
@@ -173,37 +182,55 @@ fun EventDetailScreen(eventId: String) {
                         }
                     }
 
-                    Box(
-                        modifier = Modifier
-                            .size(36.dp)
-                            .clip(CircleShape)
-                            .background(Color.White.copy(alpha = 0.85f))
-                            .clickable {
-                                val newFavorite = !isFavorite
-                                isFavorite = newFavorite
-                                AppSession.toggleFavorite(eventId, newFavorite)
-                                scope.launch {
-                                    runCatching {
-                                        if (newFavorite) {
-                                            AppContainer.favoriteService.add(eventId)
-                                        } else {
-                                            AppContainer.favoriteService.remove(eventId)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.85f))
+                                .clickable { share() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                Icons.Outlined.Share,
+                                contentDescription = "Поделиться",
+                                tint = Color.Black,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.85f))
+                                .clickable {
+                                    val newFavorite = !isFavorite
+                                    isFavorite = newFavorite
+                                    AppSession.toggleFavorite(eventId, newFavorite)
+                                    scope.launch {
+                                        runCatching {
+                                            if (newFavorite) {
+                                                AppContainer.favoriteService.add(eventId)
+                                            } else {
+                                                AppContainer.favoriteService.remove(eventId)
+                                            }
+                                        }.onFailure {
+                                            CrashReporter.log(it)
+                                            isFavorite = !newFavorite
+                                            AppSession.toggleFavorite(eventId, !newFavorite)
                                         }
-                                    }.onFailure {
-                                        CrashReporter.log(it)
-                                        isFavorite = !newFavorite
-                                        AppSession.toggleFavorite(eventId, !newFavorite)
                                     }
-                                }
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-                            contentDescription = if (isFavorite) "Убрать из избранного" else "В избранное",
-                            tint = favoriteColor,
-                            modifier = Modifier.size(18.dp)
-                        )
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                                contentDescription = if (isFavorite) "Убрать из избранного" else "В избранное",
+                                tint = favoriteColor,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.kt
@@ -1,0 +1,6 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun rememberShareLauncher(text: String): () -> Unit

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/MainViewController.kt
@@ -3,9 +3,11 @@ package com.karrad.ticketsclient
 import androidx.compose.ui.window.ComposeUIViewController
 import com.karrad.ticketsclient.di.AppContainer
 import com.karrad.ticketsclient.di.initReal
+import com.karrad.ticketsclient.push.registerPendingIosPushToken
 
 fun MainViewController() = ComposeUIViewController {
     AppContainer.initReal("https://api.example.com")
     AppSession.restoreFromStore()
+    registerPendingIosPushToken()
     App()
 }

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/push/PushHooks.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/push/PushHooks.ios.kt
@@ -1,0 +1,3 @@
+package com.karrad.ticketsclient.push
+
+actual fun onAfterLogin() = registerPendingIosPushToken()

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/push/PushRegistration.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/push/PushRegistration.kt
@@ -1,0 +1,29 @@
+package com.karrad.ticketsclient.push
+
+import com.karrad.ticketsclient.AppSession
+import com.karrad.ticketsclient.di.AppContainer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+private var pendingToken: String? = null
+
+fun onApnsPushTokenReceived(tokenHex: String) {
+    pendingToken = tokenHex
+    if (AppSession.authToken == null) return
+    registerPendingToken()
+}
+
+fun registerPendingIosPushToken() {
+    if (AppSession.authToken == null) return
+    registerPendingToken()
+}
+
+private fun registerPendingToken() {
+    val token = pendingToken ?: return
+    CoroutineScope(Dispatchers.Default).launch {
+        runCatching {
+            AppContainer.pushService.registerToken(token, "ios")
+        }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/karrad/ticketsclient/ui/util/ShareUtils.ios.kt
@@ -1,0 +1,20 @@
+package com.karrad.ticketsclient.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+
+@Composable
+actual fun rememberShareLauncher(text: String): () -> Unit {
+    return remember(text) {
+        {
+            val controller = UIActivityViewController(
+                activityItems = listOf(text),
+                applicationActivities = null
+            )
+            UIApplication.sharedApplication.keyWindow?.rootViewController
+                ?.presentViewController(controller, animated = true, completion = null)
+        }
+    }
+}

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -1,0 +1,37 @@
+import UIKit
+import UserNotifications
+import ComposeApp
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            if granted {
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+        }
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let tokenHex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        PushRegistrationKt.onApnsPushTokenReceived(tokenHex: tokenHex)
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .badge])
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 @main
 struct iOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- Кнопка «Поделиться» на EventDetailScreen — иконка Share в hero рядом с Избранным
- Android: `Intent.ACTION_SEND`, iOS: `UIActivityViewController` через expect/actual
- iOS APNs push: `AppDelegate.swift` запрашивает разрешение, передаёт токен в Kotlin
- `onAfterLogin()` хук вызывается из `AppSession.login()` — iOS регистрирует pending APNs токен после входа
- При старте приложения (уже залогинен) → `registerPendingIosPushToken()` из `MainViewController`

## Test plan
- [ ] Нажать Share на карточке события → открывается системный шит
- [ ] iOS: при первом запуске запрашивается разрешение на уведомления
- [ ] iOS: после входа → APNs токен регистрируется на беке (POST /api/v1/push/register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)