### PR TITLE
fix: обложки мероприятий, дублирующаяся дата, дубль кнопки (#223, #225)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/event/EventDetailScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -255,26 +254,6 @@ fun EventDetailScreen(eventId: String) {
                 )
 
                 Spacer(Modifier.height(8.dp))
-
-                // Дата
-                event.time.formatEventDate()?.let { dateStr ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        Icon(
-                            Icons.Outlined.CalendarMonth,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Text(
-                            text = dateStr,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
 
                 // Сеансы (если несколько)
                 if (event.sessionTimes.size > 1) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/CreateEventViewModel.kt
@@ -105,9 +105,13 @@ class CreateEventViewModel(
                 )
                 val coverError = runCatching { eventService.uploadCover(event.id, coverFile) }
                     .exceptionOrNull()?.also { CrashReporter.log(it) }
+                // Re-fetch to get imageUrl populated after cover upload
+                val freshEvent = if (coverError == null)
+                    runCatching { eventService.getEvent(event.id) }.getOrDefault(event)
+                else event
                 _state.value = _state.value.copy(
                     isSubmitting = false,
-                    createdEvent = event,
+                    createdEvent = freshEvent,
                     error = if (coverError != null) "Мероприятие создано, но обложка не загружена" else null
                 )
             } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/org/OrgManagementScreen.kt
@@ -125,15 +125,12 @@ fun OrgManagementScreen() {
                     style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                     modifier = Modifier.weight(1f)
                 )
-                // FAB создания мероприятия — компактный в тулбаре
+                // Создать мероприятие
                 IconButton(onClick = { navigator.push(com.karrad.ticketsclient.ui.navigation.CreateEventScreen) }) {
                     Icon(Icons.Outlined.DateRange, contentDescription = "Создать мероприятие")
                 }
                 IconButton(onClick = { showAddDialog = true }) {
                     Icon(Icons.Outlined.Add, contentDescription = "Добавить участника")
-                }
-                IconButton(onClick = { navigator.push(com.karrad.ticketsclient.ui.navigation.CreateEventScreen) }) {
-                    Icon(Icons.Outlined.DateRange, contentDescription = "Создать мероприятие")
                 }
             }
 


### PR DESCRIPTION
## Summary

- **#223** `CreateEventViewModel`: рефетчить ивент после `uploadCover` чтобы `imageUrl` обновился в состоянии
- **#225** `EventDetailScreen`: убрать дублирующую строку «Дата» с иконкой CalendarMonth — время уже показано в hero-оверлее
- `OrgManagementScreen`: убрать дубль иконки «Создать мероприятие» в toolbar (появился при рефакторинге)

## Test plan

- [ ] Создать мероприятие с обложкой → перейти в EventManagementScreen → обложка отображается
- [ ] EventDetailScreen: нет дублирующейся строки с датой ниже заголовка
- [ ] OrgManagementScreen toolbar: только одна иконка «Создать мероприятие»

Closes #223
Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)