### PR TITLE
feat: category pre-filter, swipe-to-refresh, search pagination, deep links

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -14,11 +14,18 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
             android:exported="true"
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="visit-kalmykia.ru" android:pathPrefix="/events/" />
             </intent-filter>
         </activity>
         <service

--- a/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/karrad/ticketsclient/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.karrad.ticketsclient
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -19,9 +20,29 @@ class MainActivity : ComponentActivity() {
         AppSession.appVersion = BuildConfig.VERSION_NAME
         AppSession.userId?.let { CrashReporter.setUserId(it) }
         initContainer(BuildConfig.BASE_URL)
+        handleDeepLink(intent)
 
         setContent {
             App()
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleDeepLink(intent, warmStart = true)
+    }
+
+    private fun handleDeepLink(intent: Intent?, warmStart: Boolean = false) {
+        val uri = intent?.data ?: return
+        // https://visit-kalmykia.ru/events/{eventId}
+        val segments = uri.pathSegments
+        if (segments.size >= 2 && segments[0] == "events") {
+            val eventId = segments[1]
+            if (warmStart) {
+                AppSession.liveDeepLinkEventId.value = eventId
+            } else {
+                AppSession.pendingDeepLinkEventId = eventId
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/App.kt
@@ -1,15 +1,36 @@
 package com.karrad.ticketsclient
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.CurrentScreen
 import cafe.adriel.voyager.navigator.Navigator
+import com.karrad.ticketsclient.ui.navigation.EventDetailScreen
 import com.karrad.ticketsclient.ui.navigation.LoginScreen
 import com.karrad.ticketsclient.ui.navigation.MainScreen
 import com.karrad.ticketsclient.ui.theme.AppTheme
+import kotlinx.coroutines.flow.filterNotNull
 
 @Composable
 fun App() {
     AppTheme {
-        val startScreen = if (AppSession.authToken != null) MainScreen else LoginScreen
-        Navigator(screen = startScreen)
+        val deepLinkEventId = AppSession.pendingDeepLinkEventId
+        AppSession.pendingDeepLinkEventId = null
+
+        val startScreen: Screen = if (AppSession.authToken != null) MainScreen else LoginScreen
+        val screens = if (deepLinkEventId != null) {
+            listOf(startScreen, EventDetailScreen(deepLinkEventId))
+        } else {
+            listOf(startScreen)
+        }
+        Navigator(screens = screens) { navigator ->
+            LaunchedEffect(Unit) {
+                AppSession.liveDeepLinkEventId.filterNotNull().collect { eventId ->
+                    AppSession.liveDeepLinkEventId.value = null
+                    navigator.push(EventDetailScreen(eventId))
+                }
+            }
+            CurrentScreen()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/AppSession.kt
@@ -8,6 +8,7 @@ import com.karrad.ticketsclient.data.api.dto.OrgMembershipDto
 import com.karrad.ticketsclient.data.store.SessionSnapshot
 import com.karrad.ticketsclient.data.store.TokenStore
 import com.karrad.ticketsclient.push.onAfterLogin
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * In-memory app session. Holds auth state and short-lived navigation data.
@@ -61,6 +62,11 @@ object AppSession {
 
     // Версия приложения — устанавливается платформой при старте
     var appVersion: String = "1.0.0"
+
+    // Deep link — холодный старт (устанавливается до App())
+    var pendingDeepLinkEventId: String? = null
+    // Deep link — горячий старт (onNewIntent, когда приложение уже запущено)
+    val liveDeepLinkEventId = MutableStateFlow<String?>(null)
 
     // Членство в организации — загружается после входа в MainScreen
     var orgMembership: OrgMembershipDto? by mutableStateOf(null)

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/navigation/AppScreen.kt
@@ -95,9 +95,15 @@ data class OrderConfirmScreen(val eventId: String, val orderId: String, val tota
 }
 
 // Search
-object SearchScreen : Screen {
+data class SearchScreen(
+    val initialCategoryId: String? = null,
+    val initialCategoryLabel: String? = null
+) : Screen {
     @androidx.compose.runtime.Composable
-    override fun Content() = com.karrad.ticketsclient.ui.screen.search.SearchScreen()
+    override fun Content() = com.karrad.ticketsclient.ui.screen.search.SearchScreen(
+        initialCategoryId = initialCategoryId,
+        initialCategoryLabel = initialCategoryLabel
+    )
 }
 
 // Profile sub-screens

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedContent.kt
@@ -63,7 +63,7 @@ internal fun FeedContent(
     selectedDay: Int,
     onDaySelect: (Int) -> Unit,
     onEventClick: (EventDto) -> Unit,
-    onCategoryMore: (String) -> Unit = {},
+    onCategoryMore: (com.karrad.ticketsclient.data.api.dto.CategoryDto) -> Unit = {},
     hasMore: Boolean = false,
     onLoadMore: () -> Unit = {}
 ) {
@@ -100,7 +100,7 @@ internal fun FeedContent(
                 SectionHeader(
                     title = entry.category.label,
                     hasMore = true,
-                    onMore = { onCategoryMore(entry.category.label) }
+                    onMore = { onCategoryMore(entry.category) }
                 )
                 HorizontalEventRow(events = entry.events, onEventClick = onEventClick)
             }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/feed/FeedScreen.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,6 +45,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FeedScreen() {
     val navigator = LocalNavigator.currentOrThrow
@@ -50,6 +55,12 @@ fun FeedScreen() {
     val state by viewModel.state.collectAsState()
     var showFilters by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    var refreshing by remember { mutableStateOf(false) }
+    val pullRefreshState = rememberPullToRefreshState()
+
+    LaunchedEffect(state) {
+        if (state !is FeedState.Loading) refreshing = false
+    }
 
     var activeFilter by remember { mutableStateOf<FilterState?>(null) }
     var filteredEvents by remember { mutableStateOf<List<com.karrad.ticketsclient.data.api.dto.EventDto>?>(null) }
@@ -106,14 +117,19 @@ fun FeedScreen() {
         )
     }
 
+    PullToRefreshBox(
+        isRefreshing = refreshing,
+        onRefresh = { refreshing = true; viewModel.load() },
+        state = pullRefreshState,
+        modifier = Modifier.fillMaxSize().statusBarsPadding()
+    ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .statusBarsPadding()
     ) {
         FeedHeader(
-            onSearchClick = { rootNavigator.push(SearchScreen) },
+            onSearchClick = { rootNavigator.push(SearchScreen()) },
             onFilterClick = { showFilters = true },
             onCityClick = { rootNavigator.push(com.karrad.ticketsclient.ui.navigation.CityPickerScreen) },
             hasActiveFilter = activeFilter?.hasActiveFilters == true
@@ -179,7 +195,7 @@ fun FeedScreen() {
                         selectedDay = selectedDay,
                         onDaySelect = { viewModel.selectDay(it) },
                         onEventClick = { event -> rootNavigator.push(EventDetailScreen(event.id)) },
-                        onCategoryMore = { rootNavigator.push(SearchScreen) },
+                        onCategoryMore = { cat -> rootNavigator.push(SearchScreen(initialCategoryId = cat.id, initialCategoryLabel = cat.label)) },
                         hasMore = s.hasMore,
                         onLoadMore = { viewModel.loadMore() }
                     )
@@ -187,4 +203,5 @@ fun FeedScreen() {
             }
         }
     }
+    } // PullToRefreshBox
 }

--- a/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/karrad/ticketsclient/ui/screen/search/SearchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -32,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,28 +60,96 @@ import com.karrad.ticketsclient.ui.util.formatPrice
 import kotlinx.coroutines.delay
 
 @Composable
-fun SearchScreen() {
+fun SearchScreen(
+    initialCategoryId: String? = null,
+    initialCategoryLabel: String? = null
+) {
     val navigator = LocalNavigator.currentOrThrow
     var queryValue by remember { mutableStateOf(TextFieldValue("")) }
     val query = queryValue.text
     var results by remember { mutableStateOf<List<EventDto>>(emptyList()) }
     var loading by remember { mutableStateOf(false) }
+    var page by remember { mutableStateOf(0) }
+    var hasMore by remember { mutableStateOf(false) }
+    var loadingMore by remember { mutableStateOf(false) }
+    val listState = rememberLazyListState()
 
+    val reachedBottom by remember {
+        derivedStateOf {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            val total = listState.layoutInfo.totalItemsCount
+            lastVisible != null && total > 0 && lastVisible.index >= total - 2
+        }
+    }
+
+    // Initial load when category pre-filter is set
+    LaunchedEffect(Unit) {
+        if (initialCategoryId != null) {
+            loading = true
+            page = 0
+            results = try {
+                AppContainer.eventService.search(
+                    query = "",
+                    city = AppSession.city,
+                    page = 0,
+                    categoryIds = listOf(initialCategoryId)
+                )
+            } catch (e: Exception) {
+                CrashReporter.log(e)
+                emptyList()
+            }
+            hasMore = results.size >= 20
+            loading = false
+        }
+    }
+
+    // Text search with debounce
     LaunchedEffect(query) {
+        if (initialCategoryId != null && query.isEmpty()) return@LaunchedEffect
         if (query.length < 2) {
-            results = emptyList()
+            if (initialCategoryId == null) results = emptyList()
             return@LaunchedEffect
         }
-        delay(300) // debounce
+        delay(300)
         loading = true
+        page = 0
         results = try {
-            AppContainer.eventService.search(query, AppSession.city)
+            AppContainer.eventService.search(
+                query = query,
+                city = AppSession.city,
+                page = 0,
+                categoryIds = if (initialCategoryId != null) listOf(initialCategoryId) else emptyList()
+            )
         } catch (e: Exception) {
             CrashReporter.log(e)
             emptyList()
-        } finally {
-            loading = false
         }
+        hasMore = results.size >= 20
+        loading = false
+    }
+
+    // Load more on scroll
+    LaunchedEffect(reachedBottom) {
+        if (!reachedBottom || !hasMore || loadingMore || loading) return@LaunchedEffect
+        loadingMore = true
+        val nextPage = page + 1
+        val more = try {
+            AppContainer.eventService.search(
+                query = query,
+                city = AppSession.city,
+                page = nextPage,
+                categoryIds = if (initialCategoryId != null) listOf(initialCategoryId) else emptyList()
+            )
+        } catch (e: Exception) {
+            CrashReporter.log(e)
+            emptyList()
+        }
+        if (more.isNotEmpty()) {
+            results = results + more
+            page = nextPage
+        }
+        hasMore = more.size >= 20
+        loadingMore = false
     }
 
     Column(
@@ -140,7 +210,8 @@ fun SearchScreen() {
                     decorationBox = { inner ->
                         if (query.isEmpty()) {
                             Text(
-                                "Поиск событий",
+                                if (initialCategoryLabel != null) "Поиск в «$initialCategoryLabel»"
+                                else "Поиск событий",
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -170,9 +241,46 @@ fun SearchScreen() {
             }
         }
 
+        // Category chip
+        if (initialCategoryLabel != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .padding(horizontal = 12.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = initialCategoryLabel,
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+        }
+
         // ─── Результаты / подсказки ───────────────────────────────────────────
         val history = AppSession.searchHistory
         when {
+            initialCategoryId != null && loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            initialCategoryId != null -> ResultsList(
+                results = results,
+                query = query,
+                loadingMore = loadingMore,
+                listState = listState,
+                onEventClick = { event ->
+                    if (query.isNotEmpty()) AppSession.addToSearchHistory(query)
+                    navigator.push(EventDetailScreen(event.id))
+                }
+            )
             query.length < 2 && history.isNotEmpty() -> SearchHistory(
                 history = history,
                 onQuerySelected = { queryValue = TextFieldValue(it) },
@@ -183,15 +291,43 @@ fun SearchScreen() {
                 CircularProgressIndicator()
             }
             results.isEmpty() -> NotFound(query)
-            else -> LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(0.dp)
-            ) {
-                items(results, key = { it.id }) { event ->
-                    SearchResultRow(event = event, onClick = {
-                        AppSession.addToSearchHistory(query)
-                        navigator.push(EventDetailScreen(event.id))
-                    })
+            else -> ResultsList(
+                results = results,
+                query = query,
+                loadingMore = loadingMore,
+                listState = listState,
+                onEventClick = { event ->
+                    AppSession.addToSearchHistory(query)
+                    navigator.push(EventDetailScreen(event.id))
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResultsList(
+    results: List<EventDto>,
+    query: String,
+    loadingMore: Boolean,
+    listState: androidx.compose.foundation.lazy.LazyListState,
+    onEventClick: (EventDto) -> Unit
+) {
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(0.dp)
+    ) {
+        items(results, key = { it.id }) { event ->
+            SearchResultRow(event = event, onClick = { onEventClick(event) })
+        }
+        if (loadingMore) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Category pre-filter**: тап по стрелке категории в ленте открывает `SearchScreen` с предустановленным фильтром — чип категории + поиск по `categoryId`
- **Swipe-to-refresh**: `PullToRefreshBox` в `FeedScreen` (аналогично уже существующему в `TicketsScreen`)
- **Search pagination**: load more при скролле до конца списка результатов в `SearchScreen`
- **Deep links**: `AndroidManifest` intent-filter для `https://visit-kalmykia.ru/events/{id}`, обработка в `MainActivity` — холодный старт через `pendingDeepLinkEventId`, горячий через `liveDeepLinkEventId` StateFlow
- FCM уже был реализован ранее (`MyFirebaseMessagingService.kt`)

## Test plan

- [ ] Тапнуть стрелку категории в ленте → SearchScreen открывается с чипом категории и результатами
- [ ] Потянуть ленту вниз → ивенты перезагружаются
- [ ] В SearchScreen проскроллить до конца → подгружается следующая страница
- [ ] Открыть `https://visit-kalmykia.ru/events/{id}` в браузере → приложение открывается на экране мероприятия

🤖 Generated with [Claude Code](https://claude.com/claude-code)